### PR TITLE
b:button: AngularJS compatibility, refactoring and reactivation of style attribute

### DIFF
--- a/src/net/bootsfaces/render/R.java
+++ b/src/net/bootsfaces/render/R.java
@@ -301,6 +301,7 @@ public final class R {
     
     /**
      * Encodes component attributes (HTML 4 + DHTML)
+     * TODO: replace this method with CoreRenderer.renderPassThruAttributes()
      * @param rw ResponseWriter instance
      * @param attrs
      * @param alist


### PR DESCRIPTION
- If both the outcome and the fragment are omitted, the corresponding Javascript code is omitted, too. Before this fix  ng-click (of AngularJS) wouldn't work properly.
- Refactoring. Got rid of two attributes of the component. Now they're passed as parameters, reducing state and memory footprint.
- The style attribute (and probably several others) weren't rendered properly due to a recent bug fix. Restored the functionality.
- Added Javadoc.
