### PR TITLE
add support for badge at the right of a nav link

### DIFF
--- a/src/main/java/net/bootsfaces/component/NavLink.java
+++ b/src/main/java/net/bootsfaces/component/NavLink.java
@@ -53,7 +53,9 @@ import net.bootsfaces.render.Tooltip;
  * @author thecoder4.eu
  */
 
-@ResourceDependencies({ @ResourceDependency(library = "bsf", name = "css/core.css", target = "head"),
+@ResourceDependencies({ 
+	@ResourceDependency(library = "bsf", name = "css/core.css", target = "head"),
+	@ResourceDependency(library = "bsf", name = "css/badges.css", target = "head"),
 	@ResourceDependency(library = "bsf", name = "css/tooltip.css", target = "head")
 })
 @FacesComponent(C.NAVLINK_COMPONENT_TYPE)
@@ -231,6 +233,16 @@ public class NavLink extends HtmlOutcomeTargetLink {
 		} else {
 			rw.writeText(value, null);
 		}
+
+		String badge = A.asString(attrs.get(A.BADGE));
+		if (badge != null) {
+			rw.startElement("span", this);
+			rw.writeAttribute("class", "badge", null);
+			rw.writeAttribute("style", "height: 50%; overflow: auto; margin: auto; position: absolute; top: 0; bottom: 0; right: 12px;", "style");
+			rw.writeText(badge, null);
+			rw.endElement("span");			
+		}
+
 		rw.endElement("a");
 		rw.endElement(H.LI);
 	}

--- a/src/main/java/net/bootsfaces/render/A.java
+++ b/src/main/java/net/bootsfaces/render/A.java
@@ -46,6 +46,7 @@ public final class A {
     public static final String HREF="href";
     public static final String ICON="icon";
     public static final String ICONAWESOME="iconAwesome";
+    public static final String BADGE="badge";
     public static final String ICON_ALIGN=ICON+"Align";
     public static final String ICON_POS=ICON+"Pos";
     public static final String LOOK="look";

--- a/src/main/meta/META-INF/bootsfaces-b.taglib.xml
+++ b/src/main/meta/META-INF/bootsfaces-b.taglib.xml
@@ -2401,6 +2401,12 @@
       <type>java.lang.String</type>
     </attribute>
     <attribute>
+      <description><![CDATA[Badge to be placed at the right side.]]></description>
+      <name>badge</name>
+      <required>false</required>
+      <type>java.lang.String</type>
+    </attribute>    
+    <attribute>
       <description><![CDATA[Alignment can right or left.]]></description>
       <name>iconAlign</name>
       <required>false</required>


### PR DESCRIPTION
Hello all. I don't know if this could be helpful, but I wanted to add a badge next to some of my nav links, so since there was no support for it, I implemented it myself. If you think it will be useful, please include it in your repo. Thank you