### PR TITLE
bug fix: close open a tags only

### DIFF
--- a/src/main/java/net/bootsfaces/component/panel/PanelRenderer.java
+++ b/src/main/java/net/bootsfaces/component/panel/PanelRenderer.java
@@ -153,7 +153,9 @@ public class PanelRenderer extends CoreRenderer {
 				}
 
 				rw.writeText(_title, null);
-				rw.endElement("a");
+				if (isCollapsible) {
+					rw.endElement("a");
+				}
 				rw.endElement("h4");
 			} else {
 				if (isCollapsible) {


### PR DESCRIPTION
When collabsible is false, the not opened a tag should also not be closed.