### PR TITLE
spaces in panelgrid's colSpans

### DIFF
--- a/src/main/java/net/bootsfaces/component/panelGrid/PanelGridRenderer.java
+++ b/src/main/java/net/bootsfaces/component/panelGrid/PanelGridRenderer.java
@@ -116,7 +116,7 @@ public class PanelGridRenderer extends CoreRenderer {
 		{
 		    throw new FacesException("PanelGrid.colSpans attribute: Please provide a comma-separated list of integer values");
 		}
-		String[] columnList = columnsCSV.split(",");
+		String[] columnList = columnsCSV.replaceAll(" ", "").split(",");
 		int[] columns = new int[columnList.length];
 		int sum = 0;
 		for (int i = 0; i < columnList.length; i++) {


### PR DESCRIPTION
Currently, colSpans in panelGrid doesn't allow spaces (after the comma).
```xml
<b:panelGrid colSpans="1,2" />
```
This pull request is a quick solution to make this possible:
```xml
<b:panelGrid colSpans="1, 2" />
```
This is not so important, but for such a little change of code, bootsfaces becomes a bit more user friendly.