### PR TITLE
Collapsible Panels aren't functional in mobile browsers

### DIFF
--- a/src/main/java/net/bootsfaces/component/panel/PanelRenderer.java
+++ b/src/main/java/net/bootsfaces/component/panel/PanelRenderer.java
@@ -147,6 +147,7 @@ public class PanelRenderer extends CoreRenderer {
 					rw.startElement("a", panel);
 					rw.writeAttribute("data-toggle", "collapse", "null");
 					rw.writeAttribute("data-target", "#" + jQueryClientID + "content", "null");
+					rw.writeAttribute("href", "javascript:;", "null");
 					if (panel.isCollapsed()) {
 						rw.writeAttribute("class", "collapsed", null);
 					}
@@ -162,6 +163,7 @@ public class PanelRenderer extends CoreRenderer {
 					rw.startElement("a", panel);
 					rw.writeAttribute("data-toggle", "collapse", "null");
 					rw.writeAttribute("data-target", "#" + jQueryClientID + "content", "null");
+					rw.writeAttribute("href", "javascript:;", "null");
 					if (panel.isCollapsed()) {
 						rw.writeAttribute("class", "collapsed", null);
 					}


### PR DESCRIPTION
Currently Panels can't be toggled if they are collapsible on iOS (tested on an iPhone + iPad), according to https://github.com/twbs/bootstrap/issues/7447 it shouldn't be functional on Android as well. That means, you can't show or hide collapsible panels on mobile devices.

Simple solutions are adding an `href` to the `a` tag or changing the `div` into a Button.
Implementing an `href` with an actual anchor makes the page jump, so I implemented it by adding a void `href` as suggested on [SO](http://stackoverflow.com/a/925252/1644440), because that seemed like most pain-free way without breaking anything.

Already tested on iOS, but couldn't test Android yet.