### PR TITLE
removing ugly positioning

### DIFF
--- a/src/main/java/net/bootsfaces/component/dataTable/DataTableRenderer.java
+++ b/src/main/java/net/bootsfaces/component/dataTable/DataTableRenderer.java
@@ -353,7 +353,7 @@ public class DataTableRenderer extends CoreRenderer {
 			//# Convert footer column text to input textfields
 			rw.writeText( widgetVar + ".find('tfoot th').each(function() {" +
 						  "var title = $(this).text();" +
-						  "$(this).html('<input class=\"form-control input-sm\" type=\"text\" placeholder=\"Search ' + title + '\" />');" +
+						  "$(this).html('<input class=\"input-sm\" type=\"text\" placeholder=\"Search ' + title + '\" />');" +
 						  "});", null );
 			//# Add event listeners for each input
 			rw.writeText( "table.columns().every( function () {" +


### PR DESCRIPTION
whenever css class form-control is used, it add a margin-bottom to the tag. This looks ugly when surrounded by text lines as here; therefore, please accept my change request to make the paginator dropdown look more user friendly.