### PR TITLE
Refactor deprecated java.util.Date API usage

### DIFF
--- a/src/main/java/net/bootsfaces/component/datePicker/DatePicker.java
+++ b/src/main/java/net/bootsfaces/component/datePicker/DatePicker.java
@@ -26,6 +26,7 @@ import java.text.SimpleDateFormat;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.Calendar;
 import java.util.Date;
 import java.util.Iterator;
 import java.util.Locale;
@@ -161,22 +162,20 @@ public class DatePicker extends HtmlInputText {
 		// Else we use our own converter
 		sloc = selectLocale(fc.getViewRoot().getLocale(), A.asString(getAttributes().get(JQ.LOCALE)));
 		sdf = selectDateFormat(sloc, A.asString(getAttributes().get(JQ.DTFORMAT)));
-		SimpleDateFormat format = null;
-		Object date = null;
+
+		Calendar cal = Calendar.getInstance(sloc);
+		SimpleDateFormat format = new SimpleDateFormat(sdf, sloc);
+		format.setTimeZone(cal.getTimeZone());
+
 		try {
-			format = new SimpleDateFormat(sdf, sloc);
+			cal.setTime(format.parse(val));
+			cal.set(Calendar.HOUR_OF_DAY, 12);
 
-			format.setTimeZone(java.util.TimeZone.getDefault());
-
-			date = format.parse(val);
-			((Date) date).setHours(12);
-
+			return cal.getTime();
 		} catch (ParseException e) {
 			this.setValid(false);
 			throw new ConverterException(getMessage("javax.faces.converter.DateTimeConverter.DATE", val, sdf, getLabel(fc)));
 		}
-
-		return date;
 	}
 
 	@Override


### PR DESCRIPTION
Most methods of `java.util.Date` are deprecated and shouldn't be used anymore, therefore without the new Java 8 Date and Time API it's better to use a `Calendar` instead. In this special case, Maven yielded a warning at build time as well.

Also this part of the code was somehow overcomplicated (unnecessary cast, wide scoping), this should do fine.

Why are we setting hours to 12 in the first place? To get over weird timezone problems, which would produce a wrong date in certain circumstances?

**Edit**: Wait, I just saw, that there is `java.time.LocalDate` used in the `DatePicker`. How? I seriously don't understand how a Java8 feature can be used in Java6 code. This just blew my mind.