### PR TITLE
Refactor AddResourcesListener and Tooltips

### DIFF
--- a/src/main/java/net/bootsfaces/C.java
+++ b/src/main/java/net/bootsfaces/C.java
@@ -40,7 +40,7 @@ public final class C {
     
     //Font Awesome
     //public static final String P_USEFONTAWESOME ="BootsFaces_USE_FA";
-    public static final String FA_VERSION="4.5.0";
+    public static final String FA_VERSION="4.6.1";
     public static final String FONTAWESOME_CDN_URL="//maxcdn.bootstrapcdn.com/font-awesome/"+FA_VERSION+"/css/font-awesome.min.css";
     
     //Meta tags

--- a/src/main/java/net/bootsfaces/component/GenContainerDiv.java
+++ b/src/main/java/net/bootsfaces/component/GenContainerDiv.java
@@ -79,7 +79,7 @@ public class GenContainerDiv extends UIComponentBase {
         }
         context.getResponseWriter()
                .endElement("div");
-		Tooltip.activateTooltips(context, getAttributes(), this);
+		Tooltip.activateTooltips(context, this);
 
     }
 

--- a/src/main/java/net/bootsfaces/component/alert/Alert.java
+++ b/src/main/java/net/bootsfaces/component/alert/Alert.java
@@ -40,10 +40,9 @@ public class Alert extends UIComponentBase implements net.bootsfaces.render.IHas
 	public static final String DEFAULT_RENDERER = "net.bootsfaces.component.alert.Alert";
 
 	public Alert() {
-		Tooltip.addResourceFile();
+		Tooltip.addResourceFiles();
 		AddResourcesListener.addThemedCSSResource("core.css");
 		AddResourcesListener.addThemedCSSResource("alerts.css");
-		AddResourcesListener.addThemedCSSResource("tooltip.css");
 
 		setRendererType(DEFAULT_RENDERER);
 	}

--- a/src/main/java/net/bootsfaces/component/alert/AlertRenderer.java
+++ b/src/main/java/net/bootsfaces/component/alert/AlertRenderer.java
@@ -67,7 +67,7 @@ public class AlertRenderer extends CoreRenderer {
 
 		rw.startElement("div", alert);
 		rw.writeAttribute("id", clientId, "id");
-		Tooltip.generateTooltip(context, attrs, rw);
+		Tooltip.generateTooltip(context, component, rw);
 
 		String style = alert.getStyle();
 		if (null != style)

--- a/src/main/java/net/bootsfaces/component/badge/Badge.java
+++ b/src/main/java/net/bootsfaces/component/badge/Badge.java
@@ -39,7 +39,6 @@ public class Badge extends UIOutput {
 	public Badge() {
 		AddResourcesListener.addThemedCSSResource("core.css");
 		AddResourcesListener.addThemedCSSResource("badges.css");
-		AddResourcesListener.addThemedCSSResource("tooltip.css");
 		setRendererType(DEFAULT_RENDERER);
 	}
 

--- a/src/main/java/net/bootsfaces/component/badge/BadgeRenderer.java
+++ b/src/main/java/net/bootsfaces/component/badge/BadgeRenderer.java
@@ -74,7 +74,7 @@ public class BadgeRenderer extends CoreRenderer {
 			styleClass = "badge";
 		else
 			styleClass += " badge";
-		Tooltip.generateTooltip(context, component.getAttributes(), rw);
+		Tooltip.generateTooltip(context, component, rw);
 		rw.writeAttribute("class", styleClass, "class");
 		if (null != style)
 			rw.writeAttribute("style", style, "style");

--- a/src/main/java/net/bootsfaces/component/badge/BadgeRenderer.java
+++ b/src/main/java/net/bootsfaces/component/badge/BadgeRenderer.java
@@ -82,7 +82,7 @@ public class BadgeRenderer extends CoreRenderer {
 			rw.writeText(val, null);
 		}
 		rw.endElement("span");
-		Tooltip.activateTooltips(context, component.getAttributes(), component);
+		Tooltip.activateTooltips(context, component);
 	}
 
 	

--- a/src/main/java/net/bootsfaces/component/button/Button.java
+++ b/src/main/java/net/bootsfaces/component/button/Button.java
@@ -41,8 +41,7 @@ public class Button extends HtmlOutcomeTargetButton implements net.bootsfaces.re
 		setRendererType(DEFAULT_RENDERER);
 
 		AddResourcesListener.addThemedCSSResource("core.css");
-		AddResourcesListener.addThemedCSSResource("tooltip.css");
-		Tooltip.addResourceFile();
+		Tooltip.addResourceFiles();
 	}
 
 	public String getFamily() {

--- a/src/main/java/net/bootsfaces/component/button/ButtonRenderer.java
+++ b/src/main/java/net/bootsfaces/component/button/ButtonRenderer.java
@@ -84,7 +84,7 @@ public class ButtonRenderer extends CoreRenderer {
 		rw.writeAttribute("id", clientId, "id");
 		rw.writeAttribute("name", clientId, "name");
 		rw.writeAttribute("type", "button", null);
-		if(BsfUtils.StringIsValued(button.getDir())) {
+		if(BsfUtils.isStringValued(button.getDir())) {
 			rw.writeAttribute("dir", button.getDir(), "dir");
 		}
 		if (style != null) {
@@ -98,7 +98,7 @@ public class ButtonRenderer extends CoreRenderer {
 		if (null != clickHandler && clickHandler.length() > 0) {
 			rw.writeAttribute("onclick", clickHandler, null);
 		}
-		if (BsfUtils.StringIsValued(button.getDismiss())) {
+		if (BsfUtils.isStringValued(button.getDismiss())) {
 			rw.writeAttribute("data-dismiss", button.getDismiss(), null);
 		}
 		if (button.isDisabled()) {

--- a/src/main/java/net/bootsfaces/component/buttonGroup/ButtonGroup.java
+++ b/src/main/java/net/bootsfaces/component/buttonGroup/ButtonGroup.java
@@ -37,8 +37,7 @@ public class ButtonGroup extends UIComponentBase implements net.bootsfaces.rende
 	
 	public ButtonGroup() {
 		AddResourcesListener.addThemedCSSResource("core.css");
-		AddResourcesListener.addThemedCSSResource("tooltip.css");
-		Tooltip.addResourceFile();
+		Tooltip.addResourceFiles();
 		setRendererType(DEFAULT_RENDERER);
 	}
 	

--- a/src/main/java/net/bootsfaces/component/buttonToolbar/ButtonToolbar.java
+++ b/src/main/java/net/bootsfaces/component/buttonToolbar/ButtonToolbar.java
@@ -38,9 +38,8 @@ public class ButtonToolbar extends UIComponentBase implements net.bootsfaces.ren
 	public static final String DEFAULT_RENDERER = "net.bootsfaces.component.buttonToolbar.ButtonToolbar";
 
 	public ButtonToolbar() {
-		Tooltip.addResourceFile();
+		Tooltip.addResourceFiles();
 		AddResourcesListener.addThemedCSSResource("core.css");
-		AddResourcesListener.addThemedCSSResource("tooltip.css");
 		setRendererType(DEFAULT_RENDERER);
 	}
 

--- a/src/main/java/net/bootsfaces/component/canvas/Canvas.java
+++ b/src/main/java/net/bootsfaces/component/canvas/Canvas.java
@@ -37,7 +37,7 @@ public class Canvas extends UIOutput implements net.bootsfaces.render.IHasToolti
 	public static final String DEFAULT_RENDERER = "net.bootsfaces.component.canvas.Canvas";
 
 	public Canvas() {
-		Tooltip.addResourceFile();
+		Tooltip.addResourceFiles();
 		setRendererType(DEFAULT_RENDERER);
 	}
 

--- a/src/main/java/net/bootsfaces/component/carousel/Carousel.java
+++ b/src/main/java/net/bootsfaces/component/carousel/Carousel.java
@@ -51,15 +51,10 @@ public class Carousel extends UICommand
 	public static final String DEFAULT_RENDERER = "net.bootsfaces.component.carousel.Carousel";
 
 	public Carousel() {
-		Tooltip.addResourceFile();
-		// AddResourcesListener.addBasicJSResource("javax.faces", "jsf.js");
-		// AddResourcesListener.addBasicJSResource("bsf", "js/bsf.js");
+		Tooltip.addResourceFiles();
 		AddResourcesListener.addThemedCSSResource("bsf.css");
 		AddResourcesListener.addThemedCSSResource("carousel.css");
 		AddResourcesListener.addThemedCSSResource("core.css");
-		AddResourcesListener.addThemedCSSResource("tooltip.css");
-		// AddResourcesListener.addResourceToHeadButAfterJQuery(C.BSF_LIBRARY,
-		// "jq/jquery.js");
 		AddResourcesListener.addResourceToHeadButAfterJQuery(C.BSF_LIBRARY, "jq/ui/core.js");
 		setRendererType(DEFAULT_RENDERER);
 	}

--- a/src/main/java/net/bootsfaces/component/carouselCaption/CarouselCaption.java
+++ b/src/main/java/net/bootsfaces/component/carouselCaption/CarouselCaption.java
@@ -45,7 +45,7 @@ public class CarouselCaption extends UICommand
 	public static final String DEFAULT_RENDERER = "net.bootsfaces.component.carouselCaption.CarouselCaption";
 
 	public CarouselCaption() {
-		Tooltip.addResourceFile();
+		Tooltip.addResourceFiles();
 		setRendererType(DEFAULT_RENDERER);
 	}
 

--- a/src/main/java/net/bootsfaces/component/carouselCaption/CarouselCaptionRenderer.java
+++ b/src/main/java/net/bootsfaces/component/carouselCaption/CarouselCaptionRenderer.java
@@ -28,7 +28,6 @@ import javax.faces.render.FacesRenderer;
 
 import net.bootsfaces.component.ajax.AJAXRenderer;
 import net.bootsfaces.render.CoreRenderer;
-import net.bootsfaces.render.IHasTooltip;
 import net.bootsfaces.render.Tooltip;
 
 /** This class generates the HTML code of &lt;b:carouselCaption /&gt;. */
@@ -49,10 +48,7 @@ public class CarouselCaptionRenderer extends CoreRenderer {
 	 */
 	@Override
 	public void decode(FacesContext context, UIComponent component) {
-		CarouselCaption carouselCaption = (CarouselCaption) component;
-
 		new AJAXRenderer().decode(context, component);
-
 	}
 
 	/**
@@ -122,7 +118,7 @@ public class CarouselCaptionRenderer extends CoreRenderer {
 		ResponseWriter rw = context.getResponseWriter();
 		rw.endElement("div");
 		if (component instanceof CarouselCaption) {
-			Tooltip.activateTooltips(context, (IHasTooltip) component);
+			Tooltip.activateTooltips(context, component);
 		}
 
 	}

--- a/src/main/java/net/bootsfaces/component/carouselControl/CarouselControl.java
+++ b/src/main/java/net/bootsfaces/component/carouselControl/CarouselControl.java
@@ -45,7 +45,7 @@ public class CarouselControl extends UICommand
 	public static final String DEFAULT_RENDERER = "net.bootsfaces.component.carouselControl.CarouselControl";
 
 	public CarouselControl() {
-		Tooltip.addResourceFile();
+		Tooltip.addResourceFiles();
 		setRendererType(DEFAULT_RENDERER);
 	}
 

--- a/src/main/java/net/bootsfaces/component/carouselItem/CarouselItem.java
+++ b/src/main/java/net/bootsfaces/component/carouselItem/CarouselItem.java
@@ -45,7 +45,7 @@ public class CarouselItem extends UICommand
 	public static final String DEFAULT_RENDERER = "net.bootsfaces.component.carouselItem.CarouselItem";
 
 	public CarouselItem() {
-		Tooltip.addResourceFile();
+		Tooltip.addResourceFiles();
 		setRendererType(DEFAULT_RENDERER);
 	}
 

--- a/src/main/java/net/bootsfaces/component/colorPicker/ColorPicker.java
+++ b/src/main/java/net/bootsfaces/component/colorPicker/ColorPicker.java
@@ -40,15 +40,10 @@ public class ColorPicker extends HtmlInputText implements IHasTooltip, IAJAXComp
 
 	public ColorPicker() {
 		setRendererType("net.bootsfaces.component.colorPicker.ColorPicker");
-		Tooltip.addResourceFile();
-		// AddResourcesListener.addBasicJSResource("javax.faces", "jsf.js");
-		// AddResourcesListener.addBasicJSResource("bsf", "js/bsf.js");
+		Tooltip.addResourceFiles();
 		AddResourcesListener.addThemedCSSResource("bsf.css");
 		AddResourcesListener.addThemedCSSResource("jquery.minicolors.css");
 		AddResourcesListener.addThemedCSSResource("core.css");
-		AddResourcesListener.addThemedCSSResource("tooltip.css");
-		// AddResourcesListener.addResourceToHeadButAfterJQuery(C.BSF_LIBRARY,
-		// "jq/jquery.js");
 		AddResourcesListener.addResourceToHeadButAfterJQuery(C.BSF_LIBRARY, "js/jquery.minicolors.min.js");
 
 		renderLabel = FacesContext.getCurrentInstance().getExternalContext()

--- a/src/main/java/net/bootsfaces/component/colorPicker/ColorPickerRenderer.java
+++ b/src/main/java/net/bootsfaces/component/colorPicker/ColorPickerRenderer.java
@@ -224,7 +224,7 @@ public class ColorPickerRenderer extends CoreRenderer {
 					" theme: 'bootstrap' " +
 					"});" +
 					"});", null);
-		rw.writeText("document.getElementById('input_" + BsfUtils.EscapeJQuerySpecialCharsInSelector(clientId) + "').addEventListener('touchmove', function(event) {\r\n"+
+		rw.writeText("document.getElementById('input_" + BsfUtils.escapeJQuerySpecialCharsInSelector(clientId) + "').addEventListener('touchmove', function(event) {\r\n"+
 	      		  "event.preventDefault();\r\n"+
 	      	      "}, false);", null);
 		rw.endElement("script");

--- a/src/main/java/net/bootsfaces/component/colorPicker/ColorPickerRenderer.java
+++ b/src/main/java/net/bootsfaces/component/colorPicker/ColorPickerRenderer.java
@@ -215,7 +215,7 @@ public class ColorPickerRenderer extends CoreRenderer {
 		// build color picker init script
 		rw.startElement("script", colorPicker);
 		rw.writeText("$(function() {" +
-					"$('#input_" + BsfUtils.EscapeJQuerySpecialCharsInSelector(clientId) + "').minicolors({" +
+					"$('#input_" + BsfUtils.escapeJQuerySpecialCharsInSelector(clientId) + "').minicolors({" +
 					(colorPicker.getAttributes().get("control") != null ? " control: '" + colorPicker.getAttributes().get("control")  + "'," : "")  +
 					(colorPicker.getAttributes().get("format") != null ? " format: '" + colorPicker.getAttributes().get("format")  + "'," : "")  +
 					(colorPicker.getAttributes().get("opacity") != null ? " opacity: " + colorPicker.getAttributes().get("opacity")  + "," : "")  +

--- a/src/main/java/net/bootsfaces/component/column/Column.java
+++ b/src/main/java/net/bootsfaces/component/column/Column.java
@@ -38,9 +38,8 @@ public class Column extends UIOutput implements net.bootsfaces.render.IHasToolti
 	public static final String DEFAULT_RENDERER = "net.bootsfaces.component.column.Column";
 
 	public Column() {
-		Tooltip.addResourceFile();
+		Tooltip.addResourceFiles();
 		AddResourcesListener.addThemedCSSResource("core.css");
-		AddResourcesListener.addThemedCSSResource("tooltip.css");
 		setRendererType(DEFAULT_RENDERER);
 	}
 

--- a/src/main/java/net/bootsfaces/component/commandButton/CommandButton.java
+++ b/src/main/java/net/bootsfaces/component/commandButton/CommandButton.java
@@ -69,13 +69,8 @@ public class CommandButton extends UICommand implements ClientBehaviorHolder, IH
 
 	public CommandButton() {
 		setRendererType(DEFAULT_RENDERER); // this component renders itself
-		// AddResourcesListener.addBasicJSResource("javax.faces", "jsf.js");
-		// AddResourcesListener.addBasicJSResource("bsf", "js/bsf.js");
 		AddResourcesListener.addThemedCSSResource("core.css");
-		AddResourcesListener.addThemedCSSResource("tooltip.css");
-		// AddResourcesListener.addResourceToHeadButAfterJQuery(C.BSF_LIBRARY,
-		// "jq/jquery.js");
-		Tooltip.addResourceFile();
+		Tooltip.addResourceFiles();
 	}
 
 	/**

--- a/src/main/java/net/bootsfaces/component/commandButton/CommandButtonRenderer.java
+++ b/src/main/java/net/bootsfaces/component/commandButton/CommandButtonRenderer.java
@@ -149,7 +149,7 @@ public class CommandButtonRenderer extends CoreRenderer {
 
 		rw.endElement("button");
 
-		Tooltip.activateTooltips(context, attrs, component);
+		Tooltip.activateTooltips(context, component);
 	}
 
 	private String getStyleClasses(CommandButton component) {

--- a/src/main/java/net/bootsfaces/component/container/Container.java
+++ b/src/main/java/net/bootsfaces/component/container/Container.java
@@ -38,11 +38,8 @@ public class Container extends UIOutput implements net.bootsfaces.render.IHasToo
 	public static final String DEFAULT_RENDERER = "net.bootsfaces.component.container.Container";
 
 	public Container() {
-		Tooltip.addResourceFile();
-		// AddResourcesListener.addResourceToHeadButAfterJQuery(C.BSF_LIBRARY,
-		// "jq/jquery.js");
+		Tooltip.addResourceFiles();
 		AddResourcesListener.addThemedCSSResource("core.css");
-		AddResourcesListener.addThemedCSSResource("tooltip.css");
 		setRendererType(DEFAULT_RENDERER);
 	}
 

--- a/src/main/java/net/bootsfaces/component/dataTable/DataTable.java
+++ b/src/main/java/net/bootsfaces/component/dataTable/DataTable.java
@@ -523,6 +523,7 @@ public class DataTable extends UIData
 	 * Activates Multi-column search inputs. The default value is false (no multi-column searching). A java.util.Map&lt;net.bootsfaces.component.dataTable.DataTable.DataTablePropertyType, Object&gt; map on the backing bean where the state of the DataTable can be saved, and retrieved after re-rendering. <P>
 	 * @return Returns the value of the attribute, or null, if it hasn't been set by the JSF file.
 	 */
+	@SuppressWarnings("unchecked")
 	public Map<DataTablePropertyType, Object> getDataTableProperties() {
 		return  (Map<DataTablePropertyType, Object>)getStateHelper().eval(PropertyKeys.dataTableProperties);
 	}

--- a/src/main/java/net/bootsfaces/component/dataTable/DataTable.java
+++ b/src/main/java/net/bootsfaces/component/dataTable/DataTable.java
@@ -59,11 +59,10 @@ public class DataTable extends UIData
 	}
 
 	public DataTable() {
-		Tooltip.addResourceFile();
 		setRendererType(DEFAULT_RENDERER);
+		Tooltip.addResourceFiles();
 		AddResourcesListener.addThemedCSSResource("core.css");
 		AddResourcesListener.addThemedCSSResource("bsf.css");
-		AddResourcesListener.addThemedCSSResource("tooltip.css");
 	}
 
 	public void setValueExpression(String name, ValueExpression binding) {

--- a/src/main/java/net/bootsfaces/component/dataTable/DataTableRenderer.java
+++ b/src/main/java/net/bootsfaces/component/dataTable/DataTableRenderer.java
@@ -310,7 +310,7 @@ public class DataTableRenderer extends CoreRenderer {
 					 "	pageLength: " + pageLength + ", " + 
 					 "	lengthMenu: " + dataTable.getPageLengthMenu() + ", " + 
 					 "	order: " + orderString + ", " +
-					 (BsfUtils.StringIsValued(lang) ? "  language: { url: '" + lang + "' } " : "") +
+					 (BsfUtils.isStringValued(lang) ? "  language: { url: '" + lang + "' } " : "") +
 					 "});" +
 					 // "var table = " + widgetVar +".DataTable({fixedHeader: true, responsive: true});" +
 					 "var workInProgressErrorMessage = 'Multiple DataTables on the same page are not yet supported when using " +
@@ -382,9 +382,9 @@ public class DataTableRenderer extends CoreRenderer {
 		final Set<String> availableLanguages = new HashSet<String>(Arrays.asList(
 		     new String[] {"de", "en", "es", "fr", "hu", "it", "pl", "ru"}
 		));
-		if(BsfUtils.StringIsValued(dataTable.getCustomLangUrl())) {
+		if(BsfUtils.isStringValued(dataTable.getCustomLangUrl())) {
 			return dataTable.getCustomLangUrl();
-		} else if(BsfUtils.StringIsValued(dataTable.getLang())) {
+		} else if(BsfUtils.isStringValued(dataTable.getLang())) {
 			String lang = dataTable.getLang();
 			if(availableLanguages.contains(lang)) return determineLanguageUrl(fc, lang);
 		} 

--- a/src/main/java/net/bootsfaces/component/datePicker/DatePicker.java
+++ b/src/main/java/net/bootsfaces/component/datePicker/DatePicker.java
@@ -257,7 +257,7 @@ public class DatePicker extends HtmlInputText {
 				if (mode.equals("icon-popup") || mode.equals("icon-toggle")) {
 					rw.startElement("span", this);
 					rw.writeAttribute("id", clientId + "_" + ADDON, "id");
-					rw.writeAttribute("class", "input-group-addon", "class");
+					rw.writeAttribute("class", ADDON, "class");
 					IconRenderer.encodeIcon(rw, this, "calendar", false, null, null, null, false, null, null,
 							isDisabled, true, true, true);
 					rw.endElement("span");
@@ -294,7 +294,7 @@ public class DatePicker extends HtmlInputText {
 		if (mode.equals("popup-icon") || mode.equals("toggle-icon")) {
 			rw.startElement("span", this);
 			rw.writeAttribute("id", clientId + "_" + ADDON, "id");
-			rw.writeAttribute("class", "input-group-addon", "class");
+			rw.writeAttribute("class", ADDON, "class");
 
 			IconRenderer.encodeIcon(rw, this, "calendar", false, null, null, null, false, null, null, isDisabled, true,
 					true, true);

--- a/src/main/java/net/bootsfaces/component/datePicker/DatePicker.java
+++ b/src/main/java/net/bootsfaces/component/datePicker/DatePicker.java
@@ -94,7 +94,6 @@ public class DatePicker extends HtmlInputText {
 		AddResourcesListener.addThemedCSSResource("jq.ui.theme.css");
 		AddResourcesListener.addThemedCSSResource("jq.ui.datepicker.css");
 		AddResourcesListener.addThemedCSSResource("bsf.css");
-		AddResourcesListener.addThemedCSSResource("tooltip.css");
 
 		AddResourcesListener.addResourceToHeadButAfterJQuery(C.BSF_LIBRARY, "jq/ui/core.js");
 		AddResourcesListener.addResourceToHeadButAfterJQuery(C.BSF_LIBRARY, "jq/ui/datepicker.js");
@@ -117,7 +116,7 @@ public class DatePicker extends HtmlInputText {
 			}
 
 		}
-		Tooltip.addResourceFile();
+		Tooltip.addResourceFiles();
 	}
 
 	public void setValueExpression(String name, ValueExpression binding) {
@@ -189,7 +188,7 @@ public class DatePicker extends HtmlInputText {
 
 		encodeHTML(fc);
 		encodeDefaultLanguageJS(fc);
-		Tooltip.activateTooltips(fc, getAttributes(), this);
+		Tooltip.activateTooltips(fc, this);
 	}
 
 	/**

--- a/src/main/java/net/bootsfaces/component/datePicker/DatePicker.java
+++ b/src/main/java/net/bootsfaces/component/datePicker/DatePicker.java
@@ -269,7 +269,7 @@ public class DatePicker extends HtmlInputText {
 		rw.startElement("input", null);
 		rw.writeAttribute("id", clientId, null);
 		rw.writeAttribute("name", clientId, null);
-		Tooltip.generateTooltip(fc, attrs, rw);
+		Tooltip.generateTooltip(fc, this, rw);
 		rw.writeAttribute("type", type, null);
 		String styleClass = new CoreRenderer().getErrorAndRequiredClass(this, clientId);
 		rw.writeAttribute("class", "form-control " + styleClass, "class");

--- a/src/main/java/net/bootsfaces/component/defaultCommand/DefaultCommand.java
+++ b/src/main/java/net/bootsfaces/component/defaultCommand/DefaultCommand.java
@@ -52,8 +52,8 @@ public class DefaultCommand extends UIComponentBase {
 		if (form == null) {
 			throw new FacesException("The default command component must be inside a form", null);
 		} else {
-			String target = (String) attrs.get("target");
-			if (BsfUtils.StringIsValued(target)) {
+			String target = (String)attrs.get("target");
+			if(BsfUtils.isStringValued(target)) {
 				ResponseWriter rw = context.getResponseWriter();
 				String formId = form.getClientId();
 				String actionCommandId = BsfUtils.getComponentClientId(target);
@@ -61,7 +61,7 @@ public class DefaultCommand extends UIComponentBase {
 				rw.startElement("script", this);
 
 				rw.writeText("" + "$(function() { " + "    $('form#"
-						+ BsfUtils.EscapeJQuerySpecialCharsInSelector(formId) + " :input').keypress(function (e) { "
+						+ BsfUtils.escapeJQuerySpecialCharsInSelector(formId) + " :input').keypress(function (e) { "
 						+ "    if ((e.which && e.which == 13) || (e.keyCode && e.keyCode == 13)) { "
 						+ "        document.getElementById('" + actionCommandId + "').click();return false; "
 						+ "    } else { " + "        console.log('keycode not 13'); " + "        return true; "

--- a/src/main/java/net/bootsfaces/component/dropButton/DropButton.java
+++ b/src/main/java/net/bootsfaces/component/dropButton/DropButton.java
@@ -42,8 +42,7 @@ public class DropButton extends UIComponentBase implements net.bootsfaces.render
 		// "jq/jquery.js");
 		AddResourcesListener.addThemedCSSResource("dropdowns.css");
 		AddResourcesListener.addThemedCSSResource("core.css");
-		AddResourcesListener.addThemedCSSResource("tooltip.css");
-		Tooltip.addResourceFile();
+		Tooltip.addResourceFiles();
 		AddResourcesListener.addResourceToHeadButAfterJQuery("bsf", "js/dropdown.js");
 		setRendererType(DEFAULT_RENDERER);
 	}

--- a/src/main/java/net/bootsfaces/component/dropMenu/DropMenu.java
+++ b/src/main/java/net/bootsfaces/component/dropMenu/DropMenu.java
@@ -41,11 +41,11 @@ public class DropMenu extends UIComponentBase implements net.bootsfaces.render.I
 	public static final String DEFAULT_RENDERER = "net.bootsfaces.component.dropMenu.DropMenu";
 
 	public DropMenu() {
-		Tooltip.addResourceFile();
+		Tooltip.addResourceFiles();
+		// AddResourcesListener.addResourceToHeadButAfterJQuery(C.BSF_LIBRARY, "jq/jquery.js");
 		AddResourcesListener.addThemedCSSResource("dropdowns.css");
 		AddResourcesListener.addThemedCSSResource("dropdown-submenu.css");
 		AddResourcesListener.addThemedCSSResource("core.css");
-		AddResourcesListener.addThemedCSSResource("tooltip.css");
 		setRendererType(DEFAULT_RENDERER);
 	}
 

--- a/src/main/java/net/bootsfaces/component/flyOutMenu/FlyOutMenu.java
+++ b/src/main/java/net/bootsfaces/component/flyOutMenu/FlyOutMenu.java
@@ -38,9 +38,8 @@ public class FlyOutMenu extends UIOutput implements net.bootsfaces.render.IHasTo
 	public static final String DEFAULT_RENDERER = "net.bootsfaces.component.flyOutMenu.FlyOutMenu";
 
 	public FlyOutMenu() {
-		Tooltip.addResourceFile();
+		Tooltip.addResourceFiles();
 		AddResourcesListener.addThemedCSSResource("core.css");
-		AddResourcesListener.addThemedCSSResource("tooltip.css");
 		setRendererType(DEFAULT_RENDERER);
 	}
 

--- a/src/main/java/net/bootsfaces/component/focus/Focus.java
+++ b/src/main/java/net/bootsfaces/component/focus/Focus.java
@@ -47,13 +47,10 @@ public class Focus extends UIComponentBase {
 		Map<String, Object> attrs = getAttributes();
 
 		String target = (String) attrs.get("target");
-		if (!BsfUtils.StringIsValued(target)) {
-			if (this.getParent() != null)
-				target = this.getParent().getId();
-		}
-
-		//
-		if (BsfUtils.StringIsValued(target)) {
+		if(!BsfUtils.isStringValued(target) && this.getParent() != null)
+			target = this.getParent().getId();
+		
+		if(BsfUtils.isStringValued(target)) {
 			ResponseWriter rw = context.getResponseWriter();
 			String itemToFocusID = BsfUtils.getComponentClientId(target);
 

--- a/src/main/java/net/bootsfaces/component/icon/Icon.java
+++ b/src/main/java/net/bootsfaces/component/icon/Icon.java
@@ -45,11 +45,8 @@ public class Icon extends UICommand implements net.bootsfaces.render.IHasTooltip
 	public static final String DEFAULT_RENDERER = "net.bootsfaces.component.icon.Icon";
 
 	public Icon() {
-		Tooltip.addResourceFile();
-		// AddResourcesListener.addBasicJSResource("javax.faces", "jsf.js");
-		// AddResourcesListener.addBasicJSResource("bsf", "js/bsf.js");
+		Tooltip.addResourceFiles();
 		AddResourcesListener.addThemedCSSResource("core.css");
-		AddResourcesListener.addThemedCSSResource("tooltip.css");
 		AddResourcesListener.addThemedCSSResource("icons.css");
 		setRendererType(DEFAULT_RENDERER);
 	}

--- a/src/main/java/net/bootsfaces/component/icon/IconRenderer.java
+++ b/src/main/java/net/bootsfaces/component/icon/IconRenderer.java
@@ -123,7 +123,7 @@ public class IconRenderer extends AJAXRenderer {
 				rw.writeAttribute("id", c.getClientId() + "_icon", null);
 			else
 				rw.writeAttribute("id", c.getClientId(), null);
-			Tooltip.generateTooltip(FacesContext.getCurrentInstance(), c.getAttributes(), rw);
+			Tooltip.generateTooltip(FacesContext.getCurrentInstance(), c, rw);
 		}
 
 		StringBuilder sb = new StringBuilder(100); // optimize int

--- a/src/main/java/net/bootsfaces/component/iconAwesome/IconAwesome.java
+++ b/src/main/java/net/bootsfaces/component/iconAwesome/IconAwesome.java
@@ -38,11 +38,10 @@ public class IconAwesome extends Icon {
 	public static final String DEFAULT_RENDERER = "net.bootsfaces.component.iconAwesome.IconAwesome";
 
 	public IconAwesome() {
-		Tooltip.addResourceFile();
+		Tooltip.addResourceFiles();
 		AddResourcesListener.addBasicJSResource("javax.faces", "jsf.js");
 		AddResourcesListener.addBasicJSResource("bsf", "js/bsf.js");
 		AddResourcesListener.addThemedCSSResource("core.css");
-		AddResourcesListener.addThemedCSSResource("tooltip.css");
 		// AddResourcesListener.addThemedCSSResource("font-awesome.css");
 		setRendererType(DEFAULT_RENDERER);
 	}

--- a/src/main/java/net/bootsfaces/component/image/Image.java
+++ b/src/main/java/net/bootsfaces/component/image/Image.java
@@ -26,12 +26,9 @@ implements net.bootsfaces.render.IHasTooltip, IAJAXComponent, ClientBehaviorHold
 
 	public static final String DEFAULT_RENDERER = "net.bootsfaces.component.image.Image";
 
-	public Image() {
-		Tooltip.addResourceFile();
-		// AddResourcesListener.addBasicJSResource("javax.faces", "jsf.js");
-		// AddResourcesListener.addBasicJSResource("bsf", "js/bsf.js");
+    public Image() {
+        Tooltip.addResourceFiles();
 		AddResourcesListener.addThemedCSSResource("core.css");
-		AddResourcesListener.addThemedCSSResource("tooltip.css");
 		AddResourcesListener.addThemedCSSResource("bsf.css");
 		setRendererType(DEFAULT_RENDERER);
 	}

--- a/src/main/java/net/bootsfaces/component/inputText/InputText.java
+++ b/src/main/java/net/bootsfaces/component/inputText/InputText.java
@@ -21,7 +21,6 @@ import java.util.Map;
 import javax.el.ValueExpression;
 import javax.faces.component.FacesComponent;
 import javax.faces.component.html.HtmlInputText;
-import javax.faces.context.FacesContext;
 
 import net.bootsfaces.C;
 import net.bootsfaces.beans.ELTools;
@@ -83,8 +82,7 @@ public class InputText extends HtmlInputText implements IHasTooltip, IAJAXCompon
 		AddResourcesListener.addBasicJSResource("bsf", "js/bsf.js");
 		AddResourcesListener.addThemedCSSResource("core.css");
 		AddResourcesListener.addThemedCSSResource("bsf.css");
-		renderLabel = FacesContext.getCurrentInstance().getExternalContext()
-				.getInitParameter("net.bootsfaces.defaults.renderLabel");
+		renderLabel= BsfUtils.getInitParam("net.bootsfaces.defaults.renderLabel");
 		if (null != renderLabel && renderLabel.contains("#{")) {
 			renderLabel = ELTools.evalAsString(renderLabel);
 		}

--- a/src/main/java/net/bootsfaces/component/inputText/InputText.java
+++ b/src/main/java/net/bootsfaces/component/inputText/InputText.java
@@ -78,11 +78,10 @@ public class InputText extends HtmlInputText implements IHasTooltip, IAJAXCompon
 
 	public InputText() {
 		setRendererType("net.bootsfaces.component.inputText.InputText");
-		Tooltip.addResourceFile();
+		Tooltip.addResourceFiles();
 		AddResourcesListener.addBasicJSResource("javax.faces", "jsf.js");
 		AddResourcesListener.addBasicJSResource("bsf", "js/bsf.js");
 		AddResourcesListener.addThemedCSSResource("core.css");
-		AddResourcesListener.addThemedCSSResource("tooltip.css");
 		AddResourcesListener.addThemedCSSResource("bsf.css");
 		renderLabel = FacesContext.getCurrentInstance().getExternalContext()
 				.getInitParameter("net.bootsfaces.defaults.renderLabel");

--- a/src/main/java/net/bootsfaces/component/inputTextarea/InputTextarea.java
+++ b/src/main/java/net/bootsfaces/component/inputTextarea/InputTextarea.java
@@ -80,8 +80,8 @@ public class InputTextarea extends HtmlInputText implements IHasTooltip, IAJAXCo
 
 	public InputTextarea() {
 		setRendererType("net.bootsfaces.component.InputTextareaRenderer");
-		AddResourcesListener.addBasicJSResource("javax.faces", "jsf.js");
-		AddResourcesListener.addBasicJSResource("bsf", "js/bsf.js");
+//		AddResourcesListener.addBasicJSResource("javax.faces", "jsf.js");
+//		AddResourcesListener.addBasicJSResource("bsf", "js/bsf.js");
 		AddResourcesListener.addThemedCSSResource("core.css");
 		AddResourcesListener.addThemedCSSResource("bsf.css");
 		Tooltip.addResourceFiles();

--- a/src/main/java/net/bootsfaces/component/inputTextarea/InputTextarea.java
+++ b/src/main/java/net/bootsfaces/component/inputTextarea/InputTextarea.java
@@ -83,9 +83,8 @@ public class InputTextarea extends HtmlInputText implements IHasTooltip, IAJAXCo
 		AddResourcesListener.addBasicJSResource("javax.faces", "jsf.js");
 		AddResourcesListener.addBasicJSResource("bsf", "js/bsf.js");
 		AddResourcesListener.addThemedCSSResource("core.css");
-		AddResourcesListener.addThemedCSSResource("tooltip.css");
 		AddResourcesListener.addThemedCSSResource("bsf.css");
-		Tooltip.addResourceFile();
+		Tooltip.addResourceFiles();
 	}
 
 	public void setValueExpression(String name, ValueExpression binding) {

--- a/src/main/java/net/bootsfaces/component/jumbotron/Jumbotron.java
+++ b/src/main/java/net/bootsfaces/component/jumbotron/Jumbotron.java
@@ -39,9 +39,8 @@ public class Jumbotron extends UIOutput implements net.bootsfaces.render.IHasToo
 
 	public Jumbotron() {
 
-		Tooltip.addResourceFile();
+		Tooltip.addResourceFiles();
 		AddResourcesListener.addThemedCSSResource("core.css");
-		AddResourcesListener.addThemedCSSResource("tooltip.css");
 		AddResourcesListener.addThemedCSSResource("jumbotron.css");
 		setRendererType(DEFAULT_RENDERER);
 	}

--- a/src/main/java/net/bootsfaces/component/jumbotron/JumbotronRenderer.java
+++ b/src/main/java/net/bootsfaces/component/jumbotron/JumbotronRenderer.java
@@ -57,13 +57,13 @@ public class JumbotronRenderer extends CoreRenderer {
 		rw.startElement("div", jumbotron);
 		rw.writeAttribute("id",clientId,"id");
 		
-		if(BsfUtils.StringIsValued(jumbotron.getStyle()))
+		if(BsfUtils.isStringValued(jumbotron.getStyle()))
 			rw.writeAttribute("style", jumbotron.getStyle(), "style");
 		
 		Tooltip.generateTooltip(context, jumbotron, rw);
 		
 		String styleClass = "jumbotron";
-		if(BsfUtils.StringIsValued(jumbotron.getStyleClass()))
+		if(BsfUtils.isStringValued(jumbotron.getStyleClass()))
 			styleClass = styleClass + " " + jumbotron.getStyleClass();
 		rw.writeAttribute("class", styleClass, "class");
 	}

--- a/src/main/java/net/bootsfaces/component/label/Label.java
+++ b/src/main/java/net/bootsfaces/component/label/Label.java
@@ -53,9 +53,8 @@ public class Label extends UIComponentBase {
 	public Label() {
 		setRendererType(null); // this component renders itself
 		AddResourcesListener.addThemedCSSResource("core.css");
-		AddResourcesListener.addThemedCSSResource("tooltip.css");
 		AddResourcesListener.addThemedCSSResource("labels.css");
-		Tooltip.addResourceFile();
+		Tooltip.addResourceFiles();
 	}
 
 	public void setValueExpression(String name, ValueExpression binding) {
@@ -90,7 +89,7 @@ public class Label extends UIComponentBase {
 		rw.writeAttribute("class", sclass, "class");
 		rw.writeText(txt, null);
 		rw.endElement("span");
-		Tooltip.activateTooltips(context, this.getAttributes(), this);
+		Tooltip.activateTooltips(context, this);
 	}
 
 	@Override

--- a/src/main/java/net/bootsfaces/component/label/Label.java
+++ b/src/main/java/net/bootsfaces/component/label/Label.java
@@ -79,7 +79,7 @@ public class Label extends UIComponentBase {
 
 		rw.startElement("span", this);
 		rw.writeAttribute("id", this.getClientId(), "id");
-		Tooltip.generateTooltip(context, this.getAttributes(), rw);
+		Tooltip.generateTooltip(context, this, rw);
 		String sclass = "label" + " " + "label";
 		if (sev != null) {
 			sclass += "-" + sev;

--- a/src/main/java/net/bootsfaces/component/linksContainer/LinksContainer.java
+++ b/src/main/java/net/bootsfaces/component/linksContainer/LinksContainer.java
@@ -39,7 +39,6 @@ import net.bootsfaces.utils.BsfUtils;
  */
 
 public class LinksContainer extends UIComponentBase {
-
 	/**
 	 * <p>
 	 * The standard component type for this component.
@@ -55,9 +54,8 @@ public class LinksContainer extends UIComponentBase {
 
 	public LinksContainer() {
 		setRendererType(null); // this component renders itself
-		Tooltip.addResourceFile();
+		Tooltip.addResourceFiles();
 		AddResourcesListener.addThemedCSSResource("core.css");
-		AddResourcesListener.addThemedCSSResource("tooltip.css");
 		AddResourcesListener.addThemedCSSResource("bsf.css");
 	}
 
@@ -87,7 +85,7 @@ public class LinksContainer extends UIComponentBase {
 		if (null != style && style.length() > 0) {
 			rw.writeAttribute("style", style, "style");
 		}
-		Tooltip.generateTooltip(fc, attrs, rw);
+		Tooltip.generateTooltip(fc, this, rw);
 		String styleClass = (String) attrs.get("styleClass");
 		if (null == styleClass) {
 			styleClass = "";
@@ -98,7 +96,6 @@ public class LinksContainer extends UIComponentBase {
 		} else {
 			rw.writeAttribute("class", styleClass.concat(" ").concat(getContainerStyles()), "class");
 		}
-
 	}
 
 	/**
@@ -114,12 +111,11 @@ public class LinksContainer extends UIComponentBase {
 	@Override
 	public void encodeEnd(FacesContext fc) throws IOException {
 		fc.getResponseWriter().endElement("ul");
-		Tooltip.activateTooltips(fc, getAttributes(), this);
+		Tooltip.activateTooltips(fc, this);
 	}
 
 	@Override
 	public String getFamily() {
 		return COMPONENT_FAMILY;
 	}
-
 }

--- a/src/main/java/net/bootsfaces/component/listLinks/ListLinks.java
+++ b/src/main/java/net/bootsfaces/component/listLinks/ListLinks.java
@@ -25,6 +25,7 @@ import javax.faces.component.FacesComponent;
 import net.bootsfaces.C;
 import net.bootsfaces.component.linksContainer.LinksContainer;
 import net.bootsfaces.listeners.AddResourcesListener;
+import net.bootsfaces.render.Tooltip;
 import net.bootsfaces.utils.BsfUtils;
 
 /**
@@ -57,20 +58,17 @@ public class ListLinks extends LinksContainer {
 	public ListLinks() {
 		setRendererType(null); // this component renders itself
 		AddResourcesListener.addThemedCSSResource("core.css");
-		AddResourcesListener.addThemedCSSResource("tooltip.css");
-	}
-
-	/*
-	 * <ul class="nav nav-list"> ... </ul>
-	 */
-	@Override
-	protected String getContainerStyles() {
-		return STYLE;
-	}
-
-	@Override
-	public String getFamily() {
-		return COMPONENT_FAMILY;
-	}
+		Tooltip.addResourceFiles();
+   }
+    
+    /*
+     * <ul class="nav nav-list">
+     * ...
+     * </ul>
+     */
+    @Override
+    protected String getContainerStyles() {
+        return STYLE;
+    }
 
 }

--- a/src/main/java/net/bootsfaces/component/message/Message.java
+++ b/src/main/java/net/bootsfaces/component/message/Message.java
@@ -42,7 +42,6 @@ public class Message extends UIMessage {
 	public Message() {
 		setRendererType(DEFAULT_RENDERER);
 		AddResourcesListener.addThemedCSSResource("core.css");
-		AddResourcesListener.addThemedCSSResource("tooltip.css");
 		AddResourcesListener.addThemedCSSResource("alerts.css");
 		AddResourcesListener.addThemedCSSResource("bsf.css");
 	}

--- a/src/main/java/net/bootsfaces/component/messages/Messages.java
+++ b/src/main/java/net/bootsfaces/component/messages/Messages.java
@@ -42,7 +42,6 @@ public class Messages extends javax.faces.component.UIMessages {
 	public Messages() {
 		super();
 		AddResourcesListener.addThemedCSSResource("core.css");
-		AddResourcesListener.addThemedCSSResource("tooltip.css");
 		AddResourcesListener.addThemedCSSResource("alerts.css");
 		AddResourcesListener.addThemedCSSResource("bsf.css");
 		setRendererType("net.bootsfaces.component.messages.MessagesRenderer");

--- a/src/main/java/net/bootsfaces/component/modal/Modal.java
+++ b/src/main/java/net/bootsfaces/component/modal/Modal.java
@@ -42,7 +42,6 @@ public class Modal extends UIComponentBase {
 	public Modal() {
 		setRendererType(DEFAULT_RENDERER);
 		AddResourcesListener.addThemedCSSResource("core.css");
-		AddResourcesListener.addThemedCSSResource("tooltip.css");
 		AddResourcesListener.addThemedCSSResource("modals.css");
 		// AddResourcesListener.addResourceToHeadButAfterJQuery(C.BSF_LIBRARY,
 		// "jq/jquery.js");

--- a/src/main/java/net/bootsfaces/component/navBar/NavBar.java
+++ b/src/main/java/net/bootsfaces/component/navBar/NavBar.java
@@ -51,9 +51,8 @@ public class NavBar extends UIComponentBase implements net.bootsfaces.render.IHa
 	public NavBar() {
 		// AddResourcesListener.addResourceToHeadButAfterJQuery(C.BSF_LIBRARY,
 		// "jq/jquery.js");
-		Tooltip.addResourceFile();
+		Tooltip.addResourceFiles();
 		AddResourcesListener.addThemedCSSResource("core.css");
-		AddResourcesListener.addThemedCSSResource("tooltip.css");
 		AddResourcesListener.addThemedCSSResource("navbar.css");
 		AddResourcesListener.addThemedCSSResource("bsf.css");
 		setRendererType(DEFAULT_RENDERER);

--- a/src/main/java/net/bootsfaces/component/navBar/NavBarRenderer.java
+++ b/src/main/java/net/bootsfaces/component/navBar/NavBarRenderer.java
@@ -223,7 +223,7 @@ public class NavBarRenderer extends CoreRenderer {
 		rw.endElement("div"); // collapse
 		rw.endElement("div"); // container
 		rw.endElement("div"); // navbar
-		Tooltip.activateTooltips(context, component.getAttributes(), component);
+		Tooltip.activateTooltips(context, component);
 
 	}
 

--- a/src/main/java/net/bootsfaces/component/navBarLinks/NavBarLinks.java
+++ b/src/main/java/net/bootsfaces/component/navBarLinks/NavBarLinks.java
@@ -53,7 +53,6 @@ public class NavBarLinks extends LinksContainer {
     public NavBarLinks() {
         setRendererType(null); // this component renders itself
 		AddResourcesListener.addThemedCSSResource("core.css");
-		AddResourcesListener.addThemedCSSResource("tooltip.css");
     }
     
 	public void setValueExpression(String name, ValueExpression binding) {

--- a/src/main/java/net/bootsfaces/component/navCommandLink/NavCommandLink.java
+++ b/src/main/java/net/bootsfaces/component/navCommandLink/NavCommandLink.java
@@ -17,7 +17,7 @@
  *  along with BootsFaces. If not, see <http://www.gnu.org/licenses/>.
  */
 
-package net.bootsfaces.component.navLink;
+package net.bootsfaces.component.navCommandLink;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -30,6 +30,7 @@ import javax.faces.component.UICommand;
 import javax.faces.component.behavior.ClientBehaviorHolder;
 
 import net.bootsfaces.component.ajax.IAJAXComponent;
+import net.bootsfaces.component.navLink.AbstractNavLink;
 import net.bootsfaces.listeners.AddResourcesListener;
 import net.bootsfaces.render.Tooltip;
 import net.bootsfaces.utils.BsfUtils;
@@ -38,7 +39,6 @@ import net.bootsfaces.utils.BsfUtils;
 @FacesComponent("net.bootsfaces.component.navCommandLink.NavCommandLink")
 public class NavCommandLink extends UICommand
 		implements ClientBehaviorHolder, net.bootsfaces.render.IHasTooltip, IAJAXComponent, AbstractNavLink {
-
 	public static final String COMPONENT_TYPE = "net.bootsfaces.component.navCommandLink.NavCommandLink";
 
 	public static final String COMPONENT_FAMILY = "net.bootsfaces.component";

--- a/src/main/java/net/bootsfaces/component/navLink/NavCommandLink.java
+++ b/src/main/java/net/bootsfaces/component/navLink/NavCommandLink.java
@@ -46,13 +46,8 @@ public class NavCommandLink extends UICommand
 	public static final String DEFAULT_RENDERER = "net.bootsfaces.component.navLink.NavLink";
 
 	public NavCommandLink() {
-		Tooltip.addResourceFile();
-		// AddResourcesListener.addBasicJSResource("javax.faces", "jsf.js");
-		// AddResourcesListener.addBasicJSResource("bsf", "js/bsf.js");
+		Tooltip.addResourceFiles();
 		AddResourcesListener.addThemedCSSResource("core.css");
-		AddResourcesListener.addThemedCSSResource("tooltip.css");
-		// AddResourcesListener.addResourceToHeadButAfterJQuery(C.BSF_LIBRARY,
-		// "jq/jquery.js");
 		setRendererType(DEFAULT_RENDERER);
 	}
 

--- a/src/main/java/net/bootsfaces/component/navLink/NavLink.java
+++ b/src/main/java/net/bootsfaces/component/navLink/NavLink.java
@@ -46,13 +46,8 @@ public class NavLink extends HtmlOutcomeTargetLink
 	public static final String DEFAULT_RENDERER = "net.bootsfaces.component.navLink.NavLink";
 
 	public NavLink() {
-		Tooltip.addResourceFile();
-		// AddResourcesListener.addBasicJSResource("javax.faces", "jsf.js");
-		// AddResourcesListener.addBasicJSResource("bsf", "js/bsf.js");
+		Tooltip.addResourceFiles();
 		AddResourcesListener.addThemedCSSResource("core.css");
-		AddResourcesListener.addThemedCSSResource("tooltip.css");
-		// AddResourcesListener.addResourceToHeadButAfterJQuery(C.BSF_LIBRARY,
-		// "jq/jquery.js");
 		setRendererType(DEFAULT_RENDERER);
 	}
 

--- a/src/main/java/net/bootsfaces/component/navLink/NavLinkRenderer.java
+++ b/src/main/java/net/bootsfaces/component/navLink/NavLinkRenderer.java
@@ -111,7 +111,7 @@ public class NavLinkRenderer extends CoreRenderer {
 	public void encodeDivider(FacesContext context, AbstractNavLink navlink) throws IOException {
 		ResponseWriter rw = context.getResponseWriter();
 		rw.startElement("li", (UIComponent) navlink);
-		Tooltip.generateTooltip(context, navlink, rw);
+		Tooltip.generateTooltip(context, (UIComponent) navlink, rw);
 		String styleClass = navlink.getStyleClass();
 		if (null == styleClass)
 			styleClass = "";
@@ -134,7 +134,7 @@ public class NavLinkRenderer extends CoreRenderer {
 		String value = (String) ((AbstractNavLink)navlink).getValue();
 		rw.startElement("li", navlink);
 		writeAttribute(rw, "id", navlink.getClientId(context), "id");
-		Tooltip.generateTooltip(context, ((AbstractNavLink)navlink), rw);
+		Tooltip.generateTooltip(context, navlink, rw);
 		AJAXRenderer.generateBootsFacesAJAXAndJavaScript(context, (ClientBehaviorHolder)navlink, rw);
 
 		R.encodeHTML4DHTMLAttrs(rw, navlink.getAttributes(), H.ALLBUTTON);

--- a/src/main/java/net/bootsfaces/component/navLink/NavLinkRenderer.java
+++ b/src/main/java/net/bootsfaces/component/navLink/NavLinkRenderer.java
@@ -38,6 +38,7 @@ import javax.faces.render.FacesRenderer;
 import net.bootsfaces.component.ajax.AJAXRenderer;
 import net.bootsfaces.component.icon.IconRenderer;
 import net.bootsfaces.component.navBarLinks.NavBarLinks;
+import net.bootsfaces.component.navCommandLink.NavCommandLink;
 import net.bootsfaces.render.CoreRenderer;
 import net.bootsfaces.render.H;
 import net.bootsfaces.render.R;

--- a/src/main/java/net/bootsfaces/component/navLink/NavLinkRenderer.java
+++ b/src/main/java/net/bootsfaces/component/navLink/NavLinkRenderer.java
@@ -89,8 +89,7 @@ public class NavLinkRenderer extends CoreRenderer {
 				encodeHTML(context, (UIComponent) navlink);
 			}
 		} // if header
-		Tooltip.activateTooltips(context, navlink);
-
+		Tooltip.activateTooltips(context, component);
 	}
 
 	public void encodeHeader(FacesContext context, String h, UIComponent navlink) throws IOException {

--- a/src/main/java/net/bootsfaces/component/panel/Panel.java
+++ b/src/main/java/net/bootsfaces/component/panel/Panel.java
@@ -50,9 +50,8 @@ public class Panel extends UIComponentBase
 	public static final String DEFAULT_RENDERER = "net.bootsfaces.component.panel.Panel";
 
 	public Panel() {
-		Tooltip.addResourceFile();
+		Tooltip.addResourceFiles();
 		AddResourcesListener.addThemedCSSResource("core.css");
-		AddResourcesListener.addThemedCSSResource("tooltip.css");
 		AddResourcesListener.addThemedCSSResource("bsf.css");
 		AddResourcesListener.addThemedCSSResource("panels.css");
 		setRendererType(DEFAULT_RENDERER);

--- a/src/main/java/net/bootsfaces/component/panel/PanelRenderer.java
+++ b/src/main/java/net/bootsfaces/component/panel/PanelRenderer.java
@@ -264,7 +264,7 @@ public class PanelRenderer extends CoreRenderer {
 					+ "').value='true';");
 			new AJAXRenderer().generateBootsFacesAJAXAndJavaScriptForJQuery(context, component, rw, jQueryClientID+"content", eventHandlers);
 		} 
-		Tooltip.activateTooltips(context, panel.getAttributes(), panel);
+		Tooltip.activateTooltips(context, panel);
 	}
 	//  $('#j_idt40_j_idt43content').on('show.bs.collapse', function(){ document.getElementById('j_idt40_j_idt43_collapsed').value='false'; });
 }

--- a/src/main/java/net/bootsfaces/component/panelGrid/PanelGrid.java
+++ b/src/main/java/net/bootsfaces/component/panelGrid/PanelGrid.java
@@ -71,9 +71,8 @@ public class PanelGrid extends UIOutput implements net.bootsfaces.render.IHasToo
 	public static final String DEFAULT_RENDERER = "net.bootsfaces.component.panelGrid.PanelGrid";
 
 	public PanelGrid() {
-		Tooltip.addResourceFile();
+		Tooltip.addResourceFiles();
 		AddResourcesListener.addThemedCSSResource("core.css");
-		AddResourcesListener.addThemedCSSResource("tooltip.css");
 		setRendererType(DEFAULT_RENDERER);
 	}
 

--- a/src/main/java/net/bootsfaces/component/pillLinks/PillLinks.java
+++ b/src/main/java/net/bootsfaces/component/pillLinks/PillLinks.java
@@ -44,7 +44,6 @@ public class PillLinks extends LinksContainer {
 	public PillLinks() {
 		setRendererType(null); // this component renders itself
 		AddResourcesListener.addThemedCSSResource("core.css");
-		AddResourcesListener.addThemedCSSResource("tooltip.css");
 	}
 
 	public void setValueExpression(String name, ValueExpression binding) {

--- a/src/main/java/net/bootsfaces/component/poll/Poll.java
+++ b/src/main/java/net/bootsfaces/component/poll/Poll.java
@@ -30,7 +30,7 @@ import javax.faces.context.ResponseWriter;
 import javax.faces.event.ActionEvent;
 
 import net.bootsfaces.C;
-import net.bootsfaces.listeners.AddResourcesListener;
+import net.bootsfaces.render.Tooltip;
 import net.bootsfaces.utils.BsfUtils;
 
 /**
@@ -55,10 +55,8 @@ public class Poll extends HtmlCommandButton {
 	public static final String COMPONENT_FAMILY = C.BSFCOMPONENT;
 
 	public Poll() {
-		// AddResourcesListener.addBasicJSResource("javax.faces", "jsf.js");
-		AddResourcesListener.addThemedCSSResource("tooltip.css");
-
 		setRendererType(null); // this component renders itself
+		Tooltip.addResourceFiles();
 	}
 
 	public void setValueExpression(String name, ValueExpression binding) {

--- a/src/main/java/net/bootsfaces/component/progressBar/ProgressBar.java
+++ b/src/main/java/net/bootsfaces/component/progressBar/ProgressBar.java
@@ -39,7 +39,7 @@ public class ProgressBar extends UIOutput implements net.bootsfaces.render.IHasT
 
 	public ProgressBar() {
 		AddResourcesListener.addThemedCSSResource("progress-bars.css");
-		Tooltip.addResourceFile();
+		Tooltip.addResourceFiles();
 		setRendererType(DEFAULT_RENDERER);
 	}
 

--- a/src/main/java/net/bootsfaces/component/row/Row.java
+++ b/src/main/java/net/bootsfaces/component/row/Row.java
@@ -38,9 +38,8 @@ public class Row extends UIOutput implements net.bootsfaces.render.IHasTooltip {
 	public static final String DEFAULT_RENDERER = "net.bootsfaces.component.row.Row";
 
 	public Row() {
-		Tooltip.addResourceFile();
+		Tooltip.addResourceFiles();
 		AddResourcesListener.addThemedCSSResource("core.css");
-		AddResourcesListener.addThemedCSSResource("tooltip.css");
 		setRendererType(DEFAULT_RENDERER);
 	}
 

--- a/src/main/java/net/bootsfaces/component/row/RowRenderer.java
+++ b/src/main/java/net/bootsfaces/component/row/RowRenderer.java
@@ -59,7 +59,7 @@ public class RowRenderer extends CoreRenderer {
 		String clientId = row.getClientId();
 
 		rw.startElement("div", row);
-		Tooltip.generateTooltip(context, row.getAttributes(), rw);
+		Tooltip.generateTooltip(context, row, rw);
 		String dir = row.getDir();
 		if (null != dir)
 			rw.writeAttribute("dir", dir, "dir");

--- a/src/main/java/net/bootsfaces/component/row/RowRenderer.java
+++ b/src/main/java/net/bootsfaces/component/row/RowRenderer.java
@@ -75,7 +75,7 @@ public class RowRenderer extends CoreRenderer {
 		}
 		rw.writeAttribute("class", s, "class");
 
-		Tooltip.activateTooltips(context, row.getAttributes(), row);
+		Tooltip.activateTooltips(context, row);
 	}
 
 	/**

--- a/src/main/java/net/bootsfaces/component/scrollSpy/ScrollSpyRenderer.java
+++ b/src/main/java/net/bootsfaces/component/scrollSpy/ScrollSpyRenderer.java
@@ -90,17 +90,17 @@ public class ScrollSpyRenderer extends CoreRenderer {
 		
 		// Get attributes
 		String container = scrollSpy.getContainer();
-		if(!BsfUtils.StringIsValued(container)) {
+		if(!BsfUtils.isStringValued(container)) {
 			container = "body";
 		} else container = "#" + decodeAndEscapeSelectors(context, component, container);
 		
 		String target = scrollSpy.getTarget();
-		if(!BsfUtils.StringIsValued(target)) {
+		if(!BsfUtils.isStringValued(target)) {
 			target = ".navbar";
 		} else target = "#" + decodeAndEscapeSelectors(context, component, target);
 		
 		int offset = scrollSpy.getOffset();
-		if(!BsfUtils.StringIsValued(target)) {
+		if(!BsfUtils.isStringValued(target)) {
 			offset = 20;
 		} 
 		boolean smooth = scrollSpy.isSmooth();
@@ -160,7 +160,7 @@ public class ScrollSpyRenderer extends CoreRenderer {
 	 */
 	private String decodeAndEscapeSelectors(FacesContext context, UIComponent component, String selector) {
 		selector = ExpressionResolver.getComponentIDs(context, component, selector);
-		selector = BsfUtils.EscapeJQuerySpecialCharsInSelector(selector);
+		selector = BsfUtils.escapeJQuerySpecialCharsInSelector(selector);
 		
 		return selector;
 	}

--- a/src/main/java/net/bootsfaces/component/selectBooleanCheckbox/SelectBooleanCheckbox.java
+++ b/src/main/java/net/bootsfaces/component/selectBooleanCheckbox/SelectBooleanCheckbox.java
@@ -74,8 +74,8 @@ public class SelectBooleanCheckbox extends HtmlInputText implements net.bootsfac
 
 	public SelectBooleanCheckbox() {
 		Tooltip.addResourceFiles();
-		AddResourcesListener.addBasicJSResource("javax.faces", "jsf.js");
-		AddResourcesListener.addBasicJSResource("bsf", "js/bsf.js");
+//		AddResourcesListener.addBasicJSResource("javax.faces", "jsf.js");
+//		AddResourcesListener.addBasicJSResource("bsf", "js/bsf.js");
 		AddResourcesListener.addThemedCSSResource("bsf.css");
 		AddResourcesListener.addThemedCSSResource("core.css");
 		setRendererType(DEFAULT_RENDERER);

--- a/src/main/java/net/bootsfaces/component/selectBooleanCheckbox/SelectBooleanCheckbox.java
+++ b/src/main/java/net/bootsfaces/component/selectBooleanCheckbox/SelectBooleanCheckbox.java
@@ -73,12 +73,11 @@ public class SelectBooleanCheckbox extends HtmlInputText implements net.bootsfac
 	}
 
 	public SelectBooleanCheckbox() {
-		Tooltip.addResourceFile();
+		Tooltip.addResourceFiles();
 		AddResourcesListener.addBasicJSResource("javax.faces", "jsf.js");
 		AddResourcesListener.addBasicJSResource("bsf", "js/bsf.js");
 		AddResourcesListener.addThemedCSSResource("bsf.css");
 		AddResourcesListener.addThemedCSSResource("core.css");
-		AddResourcesListener.addThemedCSSResource("tooltip.css");
 		setRendererType(DEFAULT_RENDERER);
 	}
 

--- a/src/main/java/net/bootsfaces/component/selectMultiMenu/SelectMultiMenu.java
+++ b/src/main/java/net/bootsfaces/component/selectMultiMenu/SelectMultiMenu.java
@@ -44,13 +44,10 @@ public class SelectMultiMenu extends HtmlInputText implements net.bootsfaces.ren
 	public static final String DEFAULT_RENDERER = "net.bootsfaces.component.selectMultiMenu.SelectMultiMenu";
 
 	public SelectMultiMenu() {
-		Tooltip.addResourceFile();
-		// AddResourcesListener.addBasicJSResource("javax.faces", "jsf.js");
-		// AddResourcesListener.addBasicJSResource("bsf", "js/bsf.js");
+		Tooltip.addResourceFiles();
 		AddResourcesListener.addThemedCSSResource("dropdowns.css");
 		AddResourcesListener.addThemedCSSResource("bootstrap-multiselect.css");
 		AddResourcesListener.addThemedCSSResource("core.css");
-		AddResourcesListener.addThemedCSSResource("tooltip.css");
 		setRendererType(DEFAULT_RENDERER);
 	}
 

--- a/src/main/java/net/bootsfaces/component/selectOneMenu/SelectOneMenu.java
+++ b/src/main/java/net/bootsfaces/component/selectOneMenu/SelectOneMenu.java
@@ -46,13 +46,10 @@ public class SelectOneMenu extends HtmlInputText implements net.bootsfaces.rende
 	public static final String DEFAULT_RENDERER = "net.bootsfaces.component.selectOneMenu.SelectOneMenu";
 
 	public SelectOneMenu() {
-		Tooltip.addResourceFile();
-		// AddResourcesListener.addBasicJSResource("javax.faces", "jsf.js");
-		// AddResourcesListener.addBasicJSResource("bsf", "js/bsf.js");
+		Tooltip.addResourceFiles();
 		AddResourcesListener.addThemedCSSResource("dropdowns.css");
 		AddResourcesListener.addThemedCSSResource("bsf.css");
 		AddResourcesListener.addThemedCSSResource("core.css");
-		AddResourcesListener.addThemedCSSResource("tooltip.css");
 		setRendererType(DEFAULT_RENDERER);
 	}
 

--- a/src/main/java/net/bootsfaces/component/selectOneMenu/SelectOneMenuRenderer.java
+++ b/src/main/java/net/bootsfaces/component/selectOneMenu/SelectOneMenuRenderer.java
@@ -117,6 +117,8 @@ public class SelectOneMenuRenderer extends CoreRenderer {
 		String clientId = outerClientId+"Inner";
 		int span = startColSpanDiv(rw, menu);
 		rw.startElement("div", menu);
+		Tooltip.generateTooltip(context, menu, rw);
+		
 		if (menu.isInline()) {
 			rw.writeAttribute("class", "form-inline", "class");
 		} else {
@@ -482,15 +484,12 @@ public class SelectOneMenuRenderer extends CoreRenderer {
 		final String itemDescription = selectItem.getItemDescription();
 		final Object itemValue = selectItem.getItemValue();
 
-		boolean isItemLabelBlank = itemLabel == null || itemLabel.trim().length() == 0;
-		itemLabel = isItemLabelBlank ? "&nbsp;" : itemLabel;
-
 		renderOption(rw, selectedOption, index, itemLabel, itemDescription, itemValue, selectItem.isItemDisabled());
 	}
 
 	private void renderOption(ResponseWriter rw, Object selectedOption, int index, String itemLabel,
 			final String description, final Object itemValue, boolean isDisabled) throws IOException {
-		boolean isItemLabelBlank = itemLabel == null || itemLabel.trim().length() == 0;
+		boolean isItemLabelBlank = itemLabel == null || itemLabel.trim().isEmpty();
 		itemLabel = isItemLabelBlank ? "&nbsp;" : itemLabel;
 
 		rw.startElement("option", null);
@@ -513,8 +512,8 @@ public class SelectOneMenuRenderer extends CoreRenderer {
 		}
 		if (isDisabled)
 			rw.writeAttribute("disabled", "disabled", "disabled");
-                
-                rw.write(itemLabel);
+
+		rw.write(itemLabel);
 
 		rw.endElement("option");
 	}
@@ -547,7 +546,7 @@ public class SelectOneMenuRenderer extends CoreRenderer {
 	protected void renderSelectTagAttributes(ResponseWriter rw, String clientId, SelectOneMenu menu)
 			throws IOException {
 		rw.writeAttribute("id", clientId, null);
-		Tooltip.generateTooltip(FacesContext.getCurrentInstance(), menu, rw);
+		//Tooltip.generateTooltip(FacesContext.getCurrentInstance(), menu, rw);
 		rw.writeAttribute("name", clientId, null);
 
 		StringBuilder sb;

--- a/src/main/java/net/bootsfaces/component/slider/Slider.java
+++ b/src/main/java/net/bootsfaces/component/slider/Slider.java
@@ -46,12 +46,11 @@ public class Slider extends HtmlInputText implements net.bootsfaces.render.IHasT
 		AddResourcesListener.addThemedCSSResource("jq.ui.slider.css");
 		AddResourcesListener.addThemedCSSResource("bsf.css");
 		AddResourcesListener.addThemedCSSResource("core.css");
-		AddResourcesListener.addThemedCSSResource("tooltip.css");
-		AddResourcesListener.addResourceToHeadButAfterJQuery(C.BSF_LIBRARY, "jq/ui/core.js");
+        AddResourcesListener.addResourceToHeadButAfterJQuery(C.BSF_LIBRARY, "jq/ui/core.js");
 		AddResourcesListener.addResourceToHeadButAfterJQuery(C.BSF_LIBRARY, "jq/ui/widget.js");
 		AddResourcesListener.addResourceToHeadButAfterJQuery(C.BSF_LIBRARY, "jq/ui/mouse.js");
 		AddResourcesListener.addResourceToHeadButAfterJQuery(C.BSF_LIBRARY, "jq/ui/slider.js");
-		Tooltip.addResourceFile();
+		Tooltip.addResourceFiles();
 		setRendererType(DEFAULT_RENDERER);
 	}
 

--- a/src/main/java/net/bootsfaces/component/switchComponent/Switch.java
+++ b/src/main/java/net/bootsfaces/component/switchComponent/Switch.java
@@ -41,13 +41,10 @@ public class Switch extends net.bootsfaces.component.selectBooleanCheckbox.Selec
 	public static final String DEFAULT_RENDERER = "net.bootsfaces.component.switch.Switch";
 
 	public Switch() {
-		Tooltip.addResourceFile();
-		// AddResourcesListener.addBasicJSResource("javax.faces", "jsf.js");
-		// AddResourcesListener.addBasicJSResource("bsf", "js/bsf.js");
+		Tooltip.addResourceFiles();
 		AddResourcesListener.addThemedCSSResource("bootstrap-switch.css");
 		AddResourcesListener.addThemedCSSResource("bsf.css");
 		AddResourcesListener.addThemedCSSResource("core.css");
-		AddResourcesListener.addThemedCSSResource("tooltip.css");
 		setRendererType(DEFAULT_RENDERER);
 	}
 

--- a/src/main/java/net/bootsfaces/component/tab/Tab.java
+++ b/src/main/java/net/bootsfaces/component/tab/Tab.java
@@ -68,7 +68,7 @@ public class Tab extends UIOutput implements net.bootsfaces.render.IHasTooltip, 
 
 	public Tab() {
 
-		Tooltip.addResourceFile();
+		Tooltip.addResourceFiles();
 		setRendererType(DEFAULT_RENDERER);
 	}
 

--- a/src/main/java/net/bootsfaces/component/tabLinks/TabLinks.java
+++ b/src/main/java/net/bootsfaces/component/tabLinks/TabLinks.java
@@ -24,6 +24,7 @@ import javax.el.ValueExpression;
 import net.bootsfaces.C;
 import net.bootsfaces.component.linksContainer.LinksContainer;
 import net.bootsfaces.listeners.AddResourcesListener;
+import net.bootsfaces.render.Tooltip;
 import net.bootsfaces.utils.BsfUtils;
 
 /**
@@ -45,7 +46,7 @@ public class TabLinks extends LinksContainer {
 	public TabLinks() {
 		setRendererType(null); // this component renders itself
 		AddResourcesListener.addThemedCSSResource("core.css");
-		AddResourcesListener.addThemedCSSResource("tooltip.css");
+		Tooltip.addResourceFiles();
 	}
 
 	public void setValueExpression(String name, ValueExpression binding) {

--- a/src/main/java/net/bootsfaces/component/tabView/TabView.java
+++ b/src/main/java/net/bootsfaces/component/tabView/TabView.java
@@ -51,15 +51,10 @@ public class TabView extends UIOutput
 	public static final String DEFAULT_RENDERER = "net.bootsfaces.component.tabView.TabView";
 
 	public TabView() {
-		// AddResourcesListener.addResourceToHeadButAfterJQuery(C.BSF_LIBRARY,
-		// "jq/jquery.js");
-		Tooltip.addResourceFile();
-		// AddResourcesListener.addBasicJSResource("javax.faces", "jsf.js");
-		// AddResourcesListener.addBasicJSResource("javax.faces", "js/bsf.js");
+		Tooltip.addResourceFiles();
 		AddResourcesListener.addThemedCSSResource("bootstrap-treeview.min.css");
 		AddResourcesListener.addThemedCSSResource("bsf.css");
 		AddResourcesListener.addThemedCSSResource("core.css");
-		AddResourcesListener.addThemedCSSResource("tooltip.css");
 		setRendererType(DEFAULT_RENDERER);
 	}
 

--- a/src/main/java/net/bootsfaces/component/tabView/TabViewRenderer.java
+++ b/src/main/java/net/bootsfaces/component/tabView/TabViewRenderer.java
@@ -149,7 +149,7 @@ public class TabViewRenderer extends CoreRenderer {
 		}
 		
 		writer.endElement("div");
-		Tooltip.activateTooltips(context, tabView.getAttributes(), tabView);
+		Tooltip.activateTooltips(context, tabView);
 	}
 	
 	/**

--- a/src/main/java/net/bootsfaces/component/tabView/TabViewRenderer.java
+++ b/src/main/java/net/bootsfaces/component/tabView/TabViewRenderer.java
@@ -182,7 +182,7 @@ public class TabViewRenderer extends CoreRenderer {
 	throws IOException {
 		writer.startElement("ul", tabView);
 		writer.writeAttribute("id", clientId, "id");
-		Tooltip.generateTooltip(context, tabView.getAttributes(), writer);
+		Tooltip.generateTooltip(context, tabView, writer);
 		String classes = "nav ";
 		if("left".equalsIgnoreCase(tabView.getTabPosition()) || "right".equalsIgnoreCase(tabView.getTabPosition())) {
 			classes += " nav-pills nav-stacked";
@@ -362,7 +362,7 @@ public class TabViewRenderer extends CoreRenderer {
 			writer.writeAttribute("dir", tab.getDir(), "dir");
 		writer.writeAttribute("id", tab.getClientId(), "id");
 		writer.writeAttribute("role", "presentation", "role");
-		Tooltip.generateTooltip(context, tab.getAttributes(), writer);
+		Tooltip.generateTooltip(context, tab, writer);
 
 		String classes = isActive ? "active" : "";
 		if (tab.getStyleClass() != null) {

--- a/src/main/java/net/bootsfaces/component/thumbnail/Thumbnail.java
+++ b/src/main/java/net/bootsfaces/component/thumbnail/Thumbnail.java
@@ -40,9 +40,8 @@ public class Thumbnail extends UIComponentBase implements net.bootsfaces.render.
 
 	public Thumbnail() {
 
-		Tooltip.addResourceFile();
+		Tooltip.addResourceFiles();
 		AddResourcesListener.addThemedCSSResource("core.css");
-		AddResourcesListener.addThemedCSSResource("tooltip.css");
 		AddResourcesListener.addThemedCSSResource("thumbnails.css");
 		setRendererType(DEFAULT_RENDERER);
 	}

--- a/src/main/java/net/bootsfaces/component/tree/Tree.java
+++ b/src/main/java/net/bootsfaces/component/tree/Tree.java
@@ -57,7 +57,6 @@ public class Tree extends UIComponentBase implements ClientBehaviorHolder {
 		AddResourcesListener.addThemedCSSResource("bootstrap-treeview.min.css");
 		AddResourcesListener.addThemedCSSResource("bsf.css");
 		AddResourcesListener.addThemedCSSResource("core.css");
-		AddResourcesListener.addThemedCSSResource("tooltip.css");
 	}
 
 	@Override

--- a/src/main/java/net/bootsfaces/component/tree/TreeRenderer.java
+++ b/src/main/java/net/bootsfaces/component/tree/TreeRenderer.java
@@ -130,7 +130,7 @@ public class TreeRenderer extends CoreRenderer {
 		}
 		Tree tree = (Tree) component;
 		String clientId = tree.getClientId();
-		String jqClientId = BsfUtils.EscapeJQuerySpecialCharsInSelector(clientId);
+		String jqClientId = BsfUtils.escapeJQuerySpecialCharsInSelector(clientId);
 		ResponseWriter rw = context.getResponseWriter();
 		
 		final UIForm form = BsfUtils.getClosestForm(tree);
@@ -156,9 +156,9 @@ public class TreeRenderer extends CoreRenderer {
 					 	(tree.isShowIcon()  ? "showIcon: true," : "") +
 					 	(tree.isShowCheckbox() ? "showCheckbox: true," : "") +
 					 	(tree.isEnableLinks() ? "enableLinks: true," : "") +
-					 	(BsfUtils.StringIsValued(tree.getCollapseIcon()) ? "collapseIcon: '" + tree.getCollapseIcon() + "'," : "") +
-					 	(BsfUtils.StringIsValued(tree.getExpandIcon())  ? "expandIcon: '" + tree.getExpandIcon() + "'," : "") +
-					 	(BsfUtils.StringIsValued(tree.getColor())  ? "color: '" + tree.getColor() + "'," : "") +
+					 	(BsfUtils.isStringValued(tree.getCollapseIcon()) ? "collapseIcon: '" + tree.getCollapseIcon() + "'," : "") +
+					 	(BsfUtils.isStringValued(tree.getExpandIcon())  ? "expandIcon: '" + tree.getExpandIcon() + "'," : "") +
+					 	(BsfUtils.isStringValued(tree.getColor())  ? "color: '" + tree.getColor() + "'," : "") +
 						"   data: getTreeData(),   " + 
 						// enable nodeSelected event callback
 						"	onNodeSelected: function(event, data) { " +

--- a/src/main/java/net/bootsfaces/component/tree/model/TreeModelUtils.java
+++ b/src/main/java/net/bootsfaces/component/tree/model/TreeModelUtils.java
@@ -141,27 +141,27 @@ public class TreeModelUtils {
 			sb.append("\"nodeInternalId\": " + node.getNodeId() + ", "); 
 		}
 		// TEXT
-		if(BsfUtils.StringIsValued(node.getText())) {
+		if(BsfUtils.isStringValued(node.getText())) {
 			sb.append("\"text\": \"" + node.getText() + "\", ");
 		}
 		// ICON
-		if(BsfUtils.StringIsValued(node.getIcon())) {
+		if(BsfUtils.isStringValued(node.getIcon())) {
 			sb.append("\"icon\": \"" + node.getIcon() + "\", ");
 		}
 		// SELECTED ICON
-		if(BsfUtils.StringIsValued(node.getSelectedIcon())) {
+		if(BsfUtils.isStringValued(node.getSelectedIcon())) {
 			sb.append("\"selectedIcon\": \"" + node.getSelectedIcon() + "\", ");
 		}
 		// COLOR
-		if(BsfUtils.StringIsValued(node.getColor())) {
+		if(BsfUtils.isStringValued(node.getColor())) {
 			sb.append("\"color\": \"" + node.getColor() + "\", ");
 		}
 		// BACK COLOR
-		if(BsfUtils.StringIsValued(node.getBackColor())) {
+		if(BsfUtils.isStringValued(node.getBackColor())) {
 			sb.append("\"backColor\": \"" + node.getBackColor() + "\", ");
 		}
 		// HREF
-		if(BsfUtils.StringIsValued(node.getHRef())) {
+		if(BsfUtils.isStringValued(node.getHRef())) {
 			sb.append("\"href\": \"" + node.getHRef() + "\", ");
 		}	
 		// TAGS

--- a/src/main/java/net/bootsfaces/component/well/Well.java
+++ b/src/main/java/net/bootsfaces/component/well/Well.java
@@ -38,9 +38,8 @@ public class Well extends UIOutput implements net.bootsfaces.render.IHasTooltip 
 	public static final String DEFAULT_RENDERER = "net.bootsfaces.component.well.Well";
 
 	public Well() {
-		Tooltip.addResourceFile();
+		Tooltip.addResourceFiles();
 		AddResourcesListener.addThemedCSSResource("core.css");
-		AddResourcesListener.addThemedCSSResource("tooltip.css");
 		AddResourcesListener.addThemedCSSResource("wells.css");
 		setRendererType(DEFAULT_RENDERER);
 	}

--- a/src/main/java/net/bootsfaces/listeners/AddResourcesListener.java
+++ b/src/main/java/net/bootsfaces/listeners/AddResourcesListener.java
@@ -255,10 +255,9 @@ public class AddResourcesListener implements SystemEventListener {
 			for (Entry<String, String> entry : resourceMap.entrySet()) {
 				String file = entry.getValue();
 				String library = entry.getKey().substring(0, entry.getKey().length() - file.length() - 1);
-				//TODO combine if statements
-				if (!"jq/jquery.js".equals(file) || !"bsf".equals(library))
-					if (!file.startsWith("jq/ui") || !"bsf".equals(library) || loadJQueryUI)
-						createAndAddComponent(root, context, SCRIPT_RENDERER, file, library);
+				if (!"jq/jquery.js".equals(file) || !"bsf".equals(library) || 
+						!file.startsWith("jq/ui") || loadJQueryUI)
+					createAndAddComponent(root, context, SCRIPT_RENDERER, file, library);
 			}
 			viewMap.remove(RESOURCE_KEY);
 		}

--- a/src/main/java/net/bootsfaces/listeners/AddResourcesListener.java
+++ b/src/main/java/net/bootsfaces/listeners/AddResourcesListener.java
@@ -45,6 +45,7 @@ import javax.faces.event.SystemEventListener;
 
 import net.bootsfaces.C;
 import net.bootsfaces.beans.ELTools;
+import net.bootsfaces.utils.BsfUtils;
 
 /**
  * This class adds the resource needed by BootsFaces and ensures that they are
@@ -106,7 +107,7 @@ public class AddResourcesListener implements SystemEventListener {
 	 */
 	private void addMetaTags(UIViewRoot root, FacesContext context) {
 		// Check context-param
-		String viewportParam = context.getExternalContext().getInitParameter(C.P_VIEWPORT);
+		String viewportParam = BsfUtils.getInitParam(C.P_VIEWPORT, context);
 
 		viewportParam = evalELIfPossible(viewportParam);
 		String content = "width=device-width, initial-scale=1";
@@ -167,8 +168,8 @@ public class AddResourcesListener implements SystemEventListener {
 		 */
 		String theme = null;
 		String usetheme = null;
-		theme = context.getExternalContext().getInitParameter(C.P_THEME);
-		usetheme = context.getExternalContext().getInitParameter(C.P_USETHEME);
+		theme = BsfUtils.getInitParam(C.P_THEME, context);
+		usetheme = BsfUtils.getInitParam(C.P_USETHEME, context);
 		theme = evalELIfPossible(theme);
 		if (!theme.isEmpty()) {
 			if (theme.equalsIgnoreCase("custom")) {
@@ -202,8 +203,7 @@ public class AddResourcesListener implements SystemEventListener {
 		UIComponent header = findHeader(root);
 		boolean useCDNImportForFontAwesome = (null == header) || (null == header.getFacet("no-fa"));
 		if (useCDNImportForFontAwesome) {
-			String useCDN = FacesContext.getCurrentInstance().getExternalContext()
-					.getInitParameter("net.bootsfaces.get_fontawesome_from_cdn");
+			String useCDN = BsfUtils.getInitParam("net.bootsfaces.get_fontawesome_from_cdn");
 			if (null != useCDN) {
 				useCDN = ELTools.evalAsString(useCDN);
 			}
@@ -312,7 +312,8 @@ public class AddResourcesListener implements SystemEventListener {
 			}
 			viewMap.remove(RESOURCE_KEY);
 		}
-		String blockUI = FacesContext.getCurrentInstance().getExternalContext().getInitParameter("net.bootsfaces.blockUI");
+		
+		String blockUI = BsfUtils.getInitParam("net.bootsfaces.blockUI", context);
 		if (null != blockUI)
 			blockUI = ELTools.evalAsString(blockUI);
 		if (null != blockUI && isTrueOrYes(blockUI)) {
@@ -362,8 +363,7 @@ public class AddResourcesListener implements SystemEventListener {
 	}
 
 	private boolean shouldLibraryBeLoaded(String initParameter) {
-		String suppressLibrary = FacesContext.getCurrentInstance().getExternalContext()
-				.getInitParameter(initParameter);
+		String suppressLibrary = BsfUtils.getInitParam(initParameter);
 		if (suppressLibrary != null)
 			suppressLibrary = ELTools.evalAsString(suppressLibrary);
 

--- a/src/main/java/net/bootsfaces/listeners/ResourceFileComparator.java
+++ b/src/main/java/net/bootsfaces/listeners/ResourceFileComparator.java
@@ -1,0 +1,47 @@
+package net.bootsfaces.listeners;
+
+import java.util.Comparator;
+
+import javax.faces.component.UIComponent;
+
+public class ResourceFileComparator implements Comparator<UIComponent> {
+	@Override
+	public int compare(UIComponent o1, UIComponent o2) {
+		String name1 = (String) o1.getAttributes().get("name");
+		String name2 = (String) o2.getAttributes().get("name");
+		if (name1 == null)
+			return 1;
+		if (name2 == null)
+			return -1;
+		if (name1.endsWith(".js") && (!(name2.endsWith(".js"))))
+			return 1;
+		if (name2.endsWith(".js") && (!(name1.endsWith(".js"))))
+			return -1;
+		if (name1.endsWith(".js")) {
+			name1 = renameJSFile(name1);
+		}
+		if (name2.endsWith(".js")) {
+			name2 = renameJSFile(name2);
+		}
+		int result = name1.compareTo(name2);
+
+		return result;
+	}
+
+	private String renameJSFile(String name) {
+		name = name.toLowerCase();
+		if (name.contains("jquery-ui"))
+			name = "2.js"; // make it the second JS file
+		else if (name.contains("jquery"))
+			name = "1.js"; // make it the first JS file
+		else if (name.contains("ui/core.js"))
+			name = "3.js"; // make it the third JS file
+		else if (name.contains("ui/widget.js"))
+			name = "4.js"; // make it the second last JS file
+		else if (name.contains("bsf.js"))
+			name = "zzz.js"; // make it the last JS file
+		else
+			name = "keep.js"; // don't move it
+		return name;
+	}
+}

--- a/src/main/java/net/bootsfaces/render/R.java
+++ b/src/main/java/net/bootsfaces/render/R.java
@@ -126,7 +126,7 @@ public final class R {
 		}
 
 		if (null != c) {
-			Tooltip.activateTooltips(FacesContext.getCurrentInstance(), c.getAttributes(), c);
+			Tooltip.activateTooltips(FacesContext.getCurrentInstance(), c);
 		}
 	}
 

--- a/src/main/java/net/bootsfaces/render/R.java
+++ b/src/main/java/net/bootsfaces/render/R.java
@@ -69,7 +69,7 @@ public final class R {
 
 		if (c != null) {
 			rw.writeAttribute("id", c.getClientId(), "id");
-			Tooltip.generateTooltip(FacesContext.getCurrentInstance(), c.getAttributes(), rw);
+			Tooltip.generateTooltip(FacesContext.getCurrentInstance(), c, rw);
 			componentAttrs = c.getAttributes();
 		}
 
@@ -149,7 +149,7 @@ public final class R {
 
 		rw.startElement("div", c);
 		rw.writeAttribute("id", c.getClientId(fc), "id");
-		Tooltip.generateTooltip(fc, attrs, rw);
+		Tooltip.generateTooltip(fc, c, rw);
 		if (pull != null && (pull.equals("right") || pull.equals("left"))) {
 			rw.writeAttribute("class", c.getContainerStyles().concat(" ").concat("pull").concat("-").concat(pull),
 					"class");

--- a/src/main/java/net/bootsfaces/render/RJumbotron.java
+++ b/src/main/java/net/bootsfaces/render/RJumbotron.java
@@ -47,7 +47,7 @@ public enum RJumbotron {
         
         rw.startElement("div", c);
         rw.writeAttribute("id",c.getClientId(fc),"id");
-        Tooltip.generateTooltip(fc, c.getAttributes(), rw);
+        Tooltip.generateTooltip(fc, c, rw);
         rw.writeAttribute("class", jumbotron, "class");
     }
     

--- a/src/main/java/net/bootsfaces/render/RThumbnail.java
+++ b/src/main/java/net/bootsfaces/render/RThumbnail.java
@@ -58,7 +58,7 @@ public enum RThumbnail {
         ResponseWriter rw = fc.getResponseWriter();
         rw.startElement("div", c);
         rw.writeAttribute("id", c.getClientId(fc), "id");
-        Tooltip.generateTooltip(fc, c.getAttributes(), rw);
+        Tooltip.generateTooltip(fc, c, rw);
         rw.writeAttribute("class", thumbnail, "class");
         /*UIComponent capt;
         capt = c.getFacet(caption.name());

--- a/src/main/java/net/bootsfaces/render/RThumbnail.java
+++ b/src/main/java/net/bootsfaces/render/RThumbnail.java
@@ -95,6 +95,6 @@ public enum RThumbnail {
             rw.endElement("div");
         }
         rw.endElement("div");
-        Tooltip.activateTooltips(fc, c.getAttributes(), c);
+        Tooltip.activateTooltips(fc, c);
     }
 }

--- a/src/main/java/net/bootsfaces/render/RWell.java
+++ b/src/main/java/net/bootsfaces/render/RWell.java
@@ -61,7 +61,7 @@ public enum RWell {
         }
         String styleClass=(String) attrs.get("styleClass");
         if (null ==styleClass) styleClass=""; else styleClass=" "+styleClass;
-        Tooltip.generateTooltip(fc, attrs, rw);
+        Tooltip.generateTooltip(fc, c, rw);
         
         if(sz!=null) { rw.writeAttribute("class", well+" "+well+"-"+sz+styleClass,"class"); }
         else           { rw.writeAttribute("class", well+styleClass, "class"); }

--- a/src/main/java/net/bootsfaces/render/Tooltip.java
+++ b/src/main/java/net/bootsfaces/render/Tooltip.java
@@ -160,36 +160,24 @@ public class Tooltip {
 
 	}
 
-	public static void addResourceFile() {
+	/**
+	 * Adds the required resource files for tooltips to the required resources list.
+	 */
+	public static void addResourceFiles() {
 		// if (null != getAttributes().get("tooltip")) {
+		AddResourcesListener.addThemedCSSResource("tooltip.css");
 		AddResourcesListener.addResourceToHeadButAfterJQuery(C.BSF_LIBRARY, "js/tooltip.js");
 		// }
 	}
 
-	public static void activateTooltips(FacesContext context, Map<String, Object> attributes, UIComponent component)
+	public static void activateTooltips(FacesContext context, UIComponent component)
 			throws IOException {
+		Map<String, Object> attributes = component.getAttributes();
 		if (attributes.get("tooltip") != null) {
 			String id = component.getClientId();
 			id = id.replace(":", "\\\\:"); // we need to escape the id for
 											// jQuery
 			String delayOptions = generateDelayAttributes(attributes);
-			String options = "";
-			if (null != delayOptions)
-				options = "'delay':" + delayOptions + ",";
-			if (options.length() > 0)
-				options = "{" + options.substring(0, options.length() - 1) + "}";
-
-			String js = "$(function () {\n" + "$('#" + id + "').tooltip(" + options + ")\n" + "});\n";
-			context.getResponseWriter().write("<script type='text/javascript'>" + js + "</script>");
-		}
-	}
-
-	public static void activateTooltips(FacesContext context, IHasTooltip component) throws IOException {
-		if (component.getTooltip() != null) {
-			String id = ((UIComponent) component).getClientId();
-			id = id.replace(":", "\\\\:"); // we need to escape the id for
-											// jQuery
-			String delayOptions = generateDelayAttributes(component);
 			String options = "";
 			if (null != delayOptions)
 				options = "'delay':" + delayOptions + ",";

--- a/src/main/java/net/bootsfaces/render/Tooltip.java
+++ b/src/main/java/net/bootsfaces/render/Tooltip.java
@@ -151,6 +151,8 @@ public class Tooltip {
 				options = "{" + options.substring(0, options.length() - 1) + "}";
 
 			String js = "$(function () {\n" + "$('#" + id + "').tooltip(" + options + ")\n" + "});\n";
+			//destroy existing tooltips to prevent ajax bugs in some browsers and prevent memory leaks (see #323 and #220)
+			js+="$('.tooltip').tooltip('destroy'); ";
 			context.getResponseWriter().write("<script type='text/javascript'>" + js + "</script>");
 		}
 	}

--- a/src/main/java/net/bootsfaces/utils/BsfUtils.java
+++ b/src/main/java/net/bootsfaces/utils/BsfUtils.java
@@ -268,4 +268,22 @@ public class BsfUtils {
 		}
 		return null;
 	}
+	
+	/**
+	 * Shortcut for getting context parameters.
+	 * @param param context parameter name
+	 * @return value of context parameter, may be null or empty
+	 */
+	public static String getInitParam(String param) {
+		return getInitParam(param, FacesContext.getCurrentInstance());
+	}
+	
+	/**
+	 * Shortcut for getting context parameters using an already obtained FacesContext.
+	 * @param param context parameter name
+	 * @return value of context parameter, may be null or empty
+	 */
+	public static String getInitParam(String param, FacesContext context) {
+		return context.getExternalContext().getInitParameter(param);
+	}
 }

--- a/src/main/java/net/bootsfaces/utils/BsfUtils.java
+++ b/src/main/java/net/bootsfaces/utils/BsfUtils.java
@@ -62,19 +62,19 @@ public class BsfUtils {
 	 * @param str
 	 * @return
 	 */
-	public static boolean StringIsValued(String str) {
-		if(str != null && !"".equals(str.trim())) return true;
-		return false;
+	public static boolean isStringValued(String str) {
+		return str != null && !"".equals(str.trim());
 	}
 
 	/**
-	 * Get the string if is valued, otherwise return default Value
+	 *  Get the string if is not null or empty,
+	 *  otherwise return the default value
 	 * @param str
 	 * @param defaultValue
 	 * @return
 	 */
-	public static String StringOrDefault(String str, String defaultValue) {
-		if(StringIsValued(str)) return str;
+	public static String stringOrDefault(String str, String defaultValue) {
+		if(isStringValued(str)) return str;
 		return defaultValue;
 	}
 
@@ -196,24 +196,11 @@ public class BsfUtils {
 	}
 
 	/**
-	 * Get the string if is not null or empty,
-	 * otherwise return the default value
-	 * 
-	 * @param inputValue
-	 * @param defaultReturnValue
-	 * @return
-	 */
-	public static String GetOrDefault (String inputValue, String defaultReturnValue) {
-		if(StringIsValued(inputValue)) return inputValue;
-		else return defaultReturnValue;
-	}
-
-	/**
 	 * Escape special jQuery chars in selector query
 	 * @param selector
 	 * @return
 	 */
-	public static String EscapeJQuerySpecialCharsInSelector(String selector) {
+	public static String escapeJQuerySpecialCharsInSelector(String selector) {
 		String jQuerySpecialChars = "!\"#$%&'()*+,./:;<=>?@[]^`{|}~;";
 		String[] jsc = jQuerySpecialChars.split("(?!^)");
 		for(String c: jsc) {


### PR DESCRIPTION
The AddResourcesListener currently is a bit long and contains a lot of boilerplate code, therefore I made some refactorings. ~~However, **this is still WIP, so probably shouldn't be merged yet**. For example `addJavascript` is still too long (220 lines for a single method) and the `Comparator` could be moved into an own class.~~

~~I just hoped to get some feedback (since it's getting late), e.g. on the difference between `addResourceToHeadButAfterJQuery` and `addBasicJSResource`. I couldn't spot any other than the different resource keys, but somehow I couldn't just get it to run with my extracted `addResource` method. The first seems to fail whereby the latter doesn't, so I just kept `addResourceToHeadButAfterJQuery` in place until I found the difference.~~

Changes:
* made yes / no checks more readable and fixed case errors
* extracted methods to reduce boilerplate code
* reduced nesting levels
* fixed typos