### PR TITLE
Don't let @previous loop endlessly if there is no previous component

### DIFF
--- a/src/main/java/net/bootsfaces/expressions/PreviousExpressionResolver.java
+++ b/src/main/java/net/bootsfaces/expressions/PreviousExpressionResolver.java
@@ -7,6 +7,8 @@ import javax.faces.FacesException;
 import javax.faces.component.UIComponent;
 
 public class PreviousExpressionResolver implements AbstractExpressionResolver {
+	private static final String ERROR_MESSAGE = "Invalid search expression - there's no predecessor to the component ";
+	
 	public List<UIComponent> resolve(UIComponent component, List<UIComponent> parentComponents, String currentId,
 			String originalExpression, String[] parameters) {
 		List<UIComponent> result = new ArrayList<UIComponent>();
@@ -14,19 +16,16 @@ public class PreviousExpressionResolver implements AbstractExpressionResolver {
 			UIComponent grandparent = component.getParent();
 			for (int i = 0; i < grandparent.getChildCount(); i++) {
 				if (grandparent.getChildren().get(i) == parent) {
-					i--;
-					if (i >= 0) {
-						result.add(grandparent.getChildren().get(i));
-						break;
-					}
+						if(i == 0) //if this is the first element of this component tree level there is no previous
+							throw new FacesException(ERROR_MESSAGE + originalExpression);
+						//otherwise take the component before this one
+						result.add(grandparent.getChildren().get(i-1));
+						return result;
 				}
 			}
 		}
-		if (result.size() > 0) {
-			return result;
-		}
-		throw new FacesException(
-				"Invalid search expression - there's no predecessor to the component " + originalExpression);
+		
+		throw new FacesException(ERROR_MESSAGE + originalExpression);
 	}
 
 }


### PR DESCRIPTION
Due to #256, the `@previous` expression did produce an endless loop, if there was no component to be found on the same level.

This should handle that, as well as document what happens in the crucial part. The problem was, that there was no break, if i was actually below 0. In this case it just ran forever.

@stephanrauh Could you test this? I only ran very limited tests, because I usually doesn't use that expression.

This fixes #256 .