### PR TITLE
add info to maven generated MANIFEST.MF so that maven generates a similar MANIFEST.MF to gradle

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,7 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>${project.build.sourceEncoding}</project.reporting.outputEncoding>
+		<maven.build.timestamp.format>yyyyMMdd-HH:mm:ss</maven.build.timestamp.format>
 
 		<!-- compiler plugin configuation -->
 		<maven.compiler.source>1.6</maven.compiler.source>
@@ -120,6 +121,21 @@
 				<artifactId>maven-jar-plugin</artifactId>
 				<version>2.5</version>
 				<configuration>
+					<archive>
+						<manifestEntries>
+							<Built-By>BootsFaces OSP Maven builder.</Built-By>
+							<Maven-Version>${maven.version}</Maven-Version>
+							<Created-By>${java.version} (${java.vendor} ${java.vm.version})</Created-By>
+							<Bundle-Name>BootsFaces</Bundle-Name>
+							<Bundle-Version>${project.version}</Bundle-Version>
+							<Bundle-Date>${maven.build.timestamp}</Bundle-Date>
+							<Implementation-Title>BootsFaces</Implementation-Title>
+							<Implementation-Version>${project.version}</Implementation-Version>
+							<Implementation-Vendor>TheCoder4.eu</Implementation-Vendor>
+							<Implementation-Vendor-Id>eu.thecoder4</Implementation-Vendor-Id>
+							<Implementation-URL>http://www.bootsfaces.net</Implementation-URL>
+						</manifestEntries>
+					</archive>
 					<excludes>
 						<exclude>rebel.xml</exclude>
 						<exclude>.gitignore</exclude>


### PR DESCRIPTION
[The Gradle generated BootsFaces jar](http://www.bootsfaces.net/download/BootsFaces-OSP-0.8.6-dist-default.jar) contains a lot of useful info in the **`MANIFEST.MF`**. Unfortunately, [the Maven generated BootsFaces jar](http://central.maven.org/maven2/net/bootsfaces/bootsfaces/0.8.6/bootsfaces-0.8.6.jar) does not contain the same info in the **`MANIFEST.MF`**. This PR adds the info that is missing from the Maven generated **`MANIFEST.MF`**. The **`MANIFEST.MF`** files still have some minor differences, but the important information is the same. Please consider merging this PR in order to reduce the differences between the two generated jars and to provide the same info to Maven developers.

Thanks,
\- Kyle