### PR TITLE
FetchBeanInfos add validation FacesMessage Severity

### DIFF
--- a/src/main/java/net/bootsfaces/component/fetchBeanInfos/FetchBeanInfos.java
+++ b/src/main/java/net/bootsfaces/component/fetchBeanInfos/FetchBeanInfos.java
@@ -19,13 +19,19 @@
 package net.bootsfaces.component.fetchBeanInfos;
 
 import java.io.IOException;
+import java.util.Map;
 
+import javax.el.ValueExpression;
+import javax.faces.FacesException;
+import javax.faces.application.FacesMessage;
 import javax.faces.component.FacesComponent;
 import javax.faces.component.UIComponentBase;
 import javax.faces.context.FacesContext;
 import javax.faces.context.ResponseWriter;
 
 import net.bootsfaces.C;
+import net.bootsfaces.render.A;
+import net.bootsfaces.utils.BsfUtils;
 
 /**
  * The &lt;alert&gt; tag generates a colored box that can be used to display
@@ -54,15 +60,96 @@ public class FetchBeanInfos extends UIComponentBase {
 		setRendererType(null); // this component renders itself
 	}
 
+
+	/**
+	 * Provide support to snake-case attribute in EL-expression items
+	 */
+	@Override
+	public void setValueExpression(String name, ValueExpression binding) {
+		name = BsfUtils.snakeCaseToCamelCase(name);
+		super.setValueExpression(name, binding);
+	}
+
+	protected enum PropertyKeys {
+		validationSeverity,
+		severityLevel;
+		String toString;
+
+		PropertyKeys(String toString) {
+			this.toString = toString;
+		}
+
+		PropertyKeys() {}
+
+		public String toString() {
+			return ((this.toString != null) ? this.toString : super.toString());
+		}
+	}
+
+	/**
+	 * validation facesContext.maximumSeverity. Default to "false" <P>
+	 * @return Returns the value of the attribute, or null, if it hasn't been set by the JSF file.
+	 */
+	public boolean isValidationSeverity() {
+		return (boolean) (Boolean) getStateHelper().eval(PropertyKeys.validationSeverity, false);
+	}
+
+	/**
+	 * validation facesContext.maximumSeverity. Default to "false" <P>
+	 * Usually this method is called internally by the JSF engine.
+	 */
+	public void setValidationSeverity(boolean _validationSeverity) {
+		getStateHelper().put(PropertyKeys.validationSeverity, _validationSeverity);
+	}
+
+	/**
+	 * What Severity level to be Failed? Possible values: "info", "warn", "error" and "fatal" . Default to "error". <P>
+	 * @return Returns the value of the attribute, or null, if it hasn't been set by the JSF file.
+	 */
+	public String getSeverityLevel() {
+		return (String) getStateHelper().eval(PropertyKeys.severityLevel,"error");
+	}
+
+	/**
+	 * What Severity level to be Failed? Possible values: "info", "warn", "error" and "fatal" . Default to "error". <P>
+	 * Usually this method is called internally by the JSF engine.
+	 */
+	public void setSeverityLevel(String _severityLevel) {
+		getStateHelper().put(PropertyKeys.severityLevel, _severityLevel);
+	}
+
+
+
 	@Override
 	public void encodeBegin(FacesContext fc) throws IOException {
 		ResponseWriter rw = fc.getResponseWriter();
-		rw.startElement("script", this);
+		Map<String, Object> attrs = this.getAttributes();
+		boolean validationSeverity = A.toBool(attrs.get("validationSeverity"));
+		String severityLevel = A.asString(attrs.get("severityLevel"));
+
+		boolean validationFailed;
 		if (fc.isValidationFailed()) {
-			rw.writeText("validationFailed=true;", null);
-		} else {
-			rw.writeText("validationFailed=false;", null);
+			validationFailed = true;
+		} else if (validationSeverity && fc.getMaximumSeverity() != null && severityLevel != null){
+
+			int severityOrdinal;
+			if  ("info".equalsIgnoreCase(severityLevel)) {
+				severityOrdinal = FacesMessage.SEVERITY_INFO.getOrdinal();
+			} else if ("warn".equalsIgnoreCase(severityLevel)){
+				severityOrdinal = FacesMessage.SEVERITY_WARN.getOrdinal();
+			} else if ("error".equalsIgnoreCase(severityLevel)){
+				severityOrdinal = FacesMessage.SEVERITY_ERROR.getOrdinal();
+			} else if ("fatal".equalsIgnoreCase(severityLevel)){
+				severityOrdinal = FacesMessage.SEVERITY_FATAL.getOrdinal();
+			}else{
+				throw new FacesException("severityLevel not define:" + severityLevel);
+			}
+			validationFailed = fc.getMaximumSeverity().getOrdinal() >= severityOrdinal;
+		}else{
+			validationFailed = false;
 		}
+		rw.startElement("script", this);
+		rw.writeText("validationFailed=" + validationFailed + ";", null);
 		rw.endElement("script");
 
 	}

--- a/src/main/meta/META-INF/bootsfaces-b.taglib.xml
+++ b/src/main/meta/META-INF/bootsfaces-b.taglib.xml
@@ -7008,6 +7008,19 @@
 		<component>
 			<component-type>net.bootsfaces.component.fetchBeanInfos.FetchBeanInfos</component-type>
 		</component>
+
+		<attribute>
+			<description><![CDATA[Boolean value to validation FacesContext Severity.]]></description>
+			<name>validationSeverity</name>
+			<required>false</required>
+			<type>java.lang.Boolean</type>
+		</attribute>
+		<attribute>
+			<description><![CDATA[validation FacesContext Severity Level.]]></description>
+			<name>severityLevel</name>
+			<required>false</required>
+			<type>java.lang.String</type>
+		</attribute>
 	</tag>
 	
 	<!-- *********** b:flyOutMenu ************************* -->


### PR DESCRIPTION
`<b:fetchBeanInfos />` add two property ：`validationSeverity`,`severityLevel`  validation FacesMessage Severity.

Uses
```xml
<b:fetchBeanInfos  validationSeverity="true"  severityLevel="error"/>
```

if `FacesContext.getMaximumSeverity()` is ERROR or FATAL then `validationFailed` will be return true
