### PR TITLE
DateTimePicker Missing Closing Div

### DIFF
--- a/src/main/java/net/bootsfaces/component/dateTimePicker/DateTimePickerRenderer.java
+++ b/src/main/java/net/bootsfaces/component/dateTimePicker/DateTimePickerRenderer.java
@@ -265,12 +265,14 @@ public class DateTimePickerRenderer extends CoreRenderer {
 
 			// end
 			rw.endElement("div");
-			if (null != responsiveStyleClass && responsiveStyleClass.trim().length()>0) {
-				rw.endElement("div");
-			} else if (label != null) {
-				rw.endElement("div");
-			}
 		}
+
+		if (null != responsiveStyleClass && responsiveStyleClass.trim().length()>0) {
+			rw.endElement("div");
+		} else if (label != null) {
+			rw.endElement("div");
+		}
+
 		return divPrefix;
 	}
 
@@ -309,7 +311,6 @@ public class DateTimePickerRenderer extends CoreRenderer {
 			fullSelector += BsfUtils.escapeJQuerySpecialCharsInSelector(divPrefix + clientId);
 			openOnClick=true;
 		}
-		System.out.println("View date format: " + displayFormat);
 
 		rw.startElement("script", dtp);
 		rw.writeText("$(function () { " +


### PR DESCRIPTION
The reason for this pull request is that in the DateTimePicker the closing div tag was incorrectly placed within a block of code that does not always run. Therefore, only popup type DateTimePickers would ever have the correct closing div. Also, the console was being spammed with the date format on every render of this component.

See this example of why the div change is necessary:

![image](https://cloud.githubusercontent.com/assets/8848080/18414794/a8291192-7794-11e6-81d0-82a2023f4183.png)

In this image, the dark blue highlighted div is the first DateTimePicker. The light blue highlighted div (within the first DateTimePicker) is the second DateTimePicker. The first DateTimePicker is engulfing the second, when they should be separate. This made it impossible to put the pickers into separate columns and caused many other minor formatting issues.