### PR TITLE
Fixes datetimepicker update by ajax call before completly initialized

### DIFF
--- a/src/main/java/net/bootsfaces/component/ajax/AJAXRenderer.java
+++ b/src/main/java/net/bootsfaces/component/ajax/AJAXRenderer.java
@@ -632,6 +632,22 @@ public class AJAXRenderer extends CoreRenderer {
 	 */
 	public void generateBootsFacesAJAXAndJavaScriptForJQuery(FacesContext context, UIComponent component,
 			ResponseWriter rw, String jQueryExpressionOfTargetElement, Map<String, String> additionalEventHandlers) throws IOException {
+		generateBootsFacesAJAXAndJavaScriptForJQuery(context, component, rw, jQueryExpressionOfTargetElement, additionalEventHandlers, false);
+	}
+	
+	/**
+	 * Registers a callback with jQuery.
+	 *
+	 * @param context
+	 * @param component
+	 * @param rw
+	 * @param jQueryExpressionOfTargetElement
+	 * @param additionalEventHandlers
+	 * @param attachOnReady
+	 * @throws IOException
+	 */
+	public void generateBootsFacesAJAXAndJavaScriptForJQuery(FacesContext context, UIComponent component,
+			ResponseWriter rw, String jQueryExpressionOfTargetElement, Map<String, String> additionalEventHandlers, boolean attachOnReady) throws IOException {
 		if (jQueryExpressionOfTargetElement.contains(":")) {
 			if (!jQueryExpressionOfTargetElement.contains("\\\\:")) { // avoid escaping twice
 				jQueryExpressionOfTargetElement=jQueryExpressionOfTargetElement.replace(":", "\\\\:");
@@ -653,7 +669,7 @@ public class AJAXRenderer extends CoreRenderer {
 			generateAJAXCallForASingleEvent(context, (ClientBehaviorHolder) component, rw, null, event,
 			additionalEventHandler, true, event, code, parameterList);
 			if (code.length() > 0) {
-				rw.startElement("script", component);
+				rw.startElement("script", component);				
 				parameterList = "event";
 				if (null != ajaxComponent.getJQueryEventParameterLists()) {
 					if (null != ajaxComponent.getJQueryEventParameterLists().get(event))
@@ -661,6 +677,7 @@ public class AJAXRenderer extends CoreRenderer {
 				}
 				String js = "$('" + jQueryExpressionOfTargetElement + "').on('" + ajaxComponent.getJQueryEvents().get(event)
 						+ "', function(" + parameterList + "){" + code.toString() + "});";
+				if (attachOnReady) js = "$(function() { " + js + " })";
 				rw.writeText(js, null);
 				rw.endElement("script");
 			}

--- a/src/main/java/net/bootsfaces/component/dateTimePicker/DateTimePickerRenderer.java
+++ b/src/main/java/net/bootsfaces/component/dateTimePicker/DateTimePickerRenderer.java
@@ -476,6 +476,6 @@ public class DateTimePickerRenderer extends CoreRenderer {
 //			rw.writeText("$('" + fullSelector + "').data(\"DateTimePicker\").disable(); ", null);
 //		}
 		rw.endElement("script");
-		new AJAXRenderer().generateBootsFacesAJAXAndJavaScriptForJQuery(fc, dtp, rw, fullSelector, null);
+		new AJAXRenderer().generateBootsFacesAJAXAndJavaScriptForJQuery(fc, dtp, rw, fullSelector, null, true);
 	}
 }

--- a/src/main/java/net/bootsfaces/component/selectOneMenu/SelectOneMenuRenderer.java
+++ b/src/main/java/net/bootsfaces/component/selectOneMenu/SelectOneMenuRenderer.java
@@ -302,7 +302,7 @@ public class SelectOneMenuRenderer extends CoreRenderer {
         final String description = selectItem.getDescription();
         final Object itemValue = selectItem.getValue();
 
-        renderOption(context, menu, rw, index, itemLabel, description, itemValue, selectItem.isDisabled());
+        renderOption(context, menu, rw, index, itemLabel, description, itemValue, selectItem.isDisabled(), selectItem.isEscape());
     }
 
     private Converter findImplicitConverter(FacesContext context, UIComponent component) {
@@ -376,7 +376,7 @@ public class SelectOneMenuRenderer extends CoreRenderer {
     }
 
     private void renderOption(FacesContext context, SelectOneMenu menu, ResponseWriter rw, int index, String itemLabel,
-            final String description, final Object itemValue, boolean isDisabled) throws IOException {
+            final String description, final Object itemValue, boolean isDisabled, boolean isEscape) throws IOException {
         Object submittedValue = menu.getSubmittedValue();
         Object selectedOption;
         Object optionValue;
@@ -414,8 +414,11 @@ public class SelectOneMenuRenderer extends CoreRenderer {
         if (isDisabled)
             rw.writeAttribute("disabled", "disabled", "disabled");
 
-        rw.write(itemLabel);
-
+        if (isEscape)
+        	rw.writeText(itemLabel, null);
+        else
+        	rw.write(itemLabel);
+        
         rw.endElement("option");
     }
 

--- a/src/main/java/net/bootsfaces/component/selectOneMenu/SelectOneMenuRenderer.java
+++ b/src/main/java/net/bootsfaces/component/selectOneMenu/SelectOneMenuRenderer.java
@@ -414,7 +414,7 @@ public class SelectOneMenuRenderer extends CoreRenderer {
         if (isDisabled)
             rw.writeAttribute("disabled", "disabled", "disabled");
 
-        if (isEscape)
+        if (isEscape && !isItemLabelBlank)
         	rw.writeText(itemLabel, null);
         else
         	rw.write(itemLabel);


### PR DESCRIPTION
Using a b:datetimepicker with ajax update was sending an invalid (ISO)
format date to the server before initialization of the datetimepicker
itself. Moving event initialization to the jquery ready handler fixes
this behaviour.

Fix #586