### PR TITLE
b:datetimepicker issue after changing id / b:radioButton ajax update

### DIFF
--- a/src/main/java/net/bootsfaces/component/dateTimePicker/DateTimePickerCore.java
+++ b/src/main/java/net/bootsfaces/component/dateTimePicker/DateTimePickerCore.java
@@ -1039,7 +1039,7 @@ public abstract class DateTimePickerCore extends HtmlInputText implements net.bo
 	 * @return Returns the value of the attribute, or null, if it hasn't been set by the JSF file.
 	 */
 	public boolean isShowIcon() {
-		return (boolean) (Boolean) getStateHelper().eval(PropertyKeys.showIcon, false);
+		return (boolean) (Boolean) getStateHelper().eval(PropertyKeys.showIcon, true);
 	}
 
 	/**

--- a/src/main/java/net/bootsfaces/component/dateTimePicker/DateTimePickerRenderer.java
+++ b/src/main/java/net/bootsfaces/component/dateTimePicker/DateTimePickerRenderer.java
@@ -390,7 +390,7 @@ public class DateTimePickerRenderer extends CoreRenderer {
 				:
 				getDateAsString(fc, dtp, v, LocaleUtils.momentToJavaFormat(format), sloc)) + "'";
 
-		String fullSelector =  "#" + BsfUtils.escapeJQuerySpecialCharsInSelector(clientId);
+		String fullSelector =  "#" + BsfUtils.escapeJQuerySpecialCharsInSelector(fieldId);
 
 		String defaultDate = BsfUtils.isStringValued(dtp.getInitialDate()) ?
 			dtp.getInitialDate().contains("moment") ? dtp.getInitialDate() : "'" + dtp.getInitialDate() + "'" : "";

--- a/src/main/java/net/bootsfaces/component/radiobutton/Radiobutton.java
+++ b/src/main/java/net/bootsfaces/component/radiobutton/Radiobutton.java
@@ -69,7 +69,7 @@ public class Radiobutton extends RadiobuttonCore implements net.bootsfaces.rende
 		String propertyName = getValueExpression("value").getExpressionString();
 		if (propertyName.startsWith("#{") && propertyName.endsWith("}")) {
 			propertyName=propertyName.substring(2, propertyName.length()-1);
-			return "input_"+propertyName;
+			return "input_"+propertyName.trim();
 		} else {
 			throw new FacesException("The value attribute of a radiobutton must be an EL expression.");
 		}


### PR DESCRIPTION
Find another fix for dateTimePicker which was not working well after last "id" update, which switches from clientId to fieldId. clientId was still used for JQuery. 

Also it contains an improved b:radioButton ajax update handling (maybe the code in Ajax decode could be better, but for now it works) updating bean value.

See:
https://github.com/mtvweb/BootsFaces-OSP/commit/ba9bb263065c4d0cbf0cf6ca2fc5c4589af22ba7
https://github.com/mtvweb/BootsFaces-OSP/commit/ecce9cb28191830d420f6081d64707b47ba5f503