### PR TITLE
b:dataTableColumn added properties for data-order and data-search

### DIFF
--- a/src/main/java/net/bootsfaces/component/dataTable/DataTableRenderer.java
+++ b/src/main/java/net/bootsfaces/component/dataTable/DataTableRenderer.java
@@ -233,6 +233,14 @@ public class DataTableRenderer extends CoreRenderer {
 					} else if (contentStyleClass != null && styleClass!=null) {
 						rw.writeAttribute("class", styleClass + " " + contentStyleClass, null);
 					}
+					
+					Object dataOrder = column.getAttributes().get("dataOrder");
+					if (dataOrder != null)
+						rw.writeAttribute("data-order", dataOrder, null);
+					Object dataSearch = column.getAttributes().get("dataSearch");
+					if (dataSearch != null)
+						rw.writeAttribute("data-search", dataSearch, null);
+					
 					Object value = column.getAttributes().get("value");
 					if (value != null) {
 						rw.writeText(value, null);

--- a/src/main/java/net/bootsfaces/component/dataTableColumn/DataTableColumnCore.java
+++ b/src/main/java/net/bootsfaces/component/dataTableColumn/DataTableColumnCore.java
@@ -29,6 +29,8 @@ public abstract class DataTableColumnCore extends UIColumn {
 		contentStyleClass,
 		customOptions,
 		dataType,
+		dataOrder,
+		dataSearch,
 		footerStyle,
 		footerStyleClass,
 		headerStyle,
@@ -104,6 +106,38 @@ public abstract class DataTableColumnCore extends UIColumn {
 		getStateHelper().put(PropertyKeys.customOptions, _customOptions);
 	}
 
+	/**
+	 * Allows you to specify a value for ordering. Useful i.E. for ordering formatted values.<P>
+	 * Usually this method is called internally by the JSF engine.
+	 */
+	public void setDataOrder(String _dataOrder) {
+		getStateHelper().put(PropertyKeys.dataOrder, _dataOrder);
+	}
+	
+	/**
+	 * Allows you to specify a value for ordering. Useful i.E. for ordering formatted values.<P>
+	 * @return Returns the value of the attribute, or null, if it hasn't been set by the JSF file.
+	 */
+	public String getDataOrder() {
+		return (String) getStateHelper().eval(PropertyKeys.dataOrder);
+	}
+	
+	/**
+	 * Allows you to specify a value for searching. Useful i.E. for searching formatted values.<P>
+	 * Usually this method is called internally by the JSF engine.
+	 */
+	public void setDataSearch(String _dataSearch) {
+		getStateHelper().put(PropertyKeys.dataSearch, _dataSearch);
+	}
+	
+	/**
+	 * Allows you to specify a value for searching. Useful i.E. for searching formatted values.<P>
+	 * @return Returns the value of the attribute, or null, if it hasn't been set by the JSF file.
+	 */
+	public String getDataSearch() {
+		return (String) getStateHelper().eval(PropertyKeys.dataSearch);
+	}
+	
 	/**
 	 * Specifies order-by more precisely. Is also used by the filtering methods. Legal values are 'string', 'date', 'numeric'. <P>
 	 * @return Returns the value of the attribute, or null, if it hasn't been set by the JSF file.
@@ -263,6 +297,7 @@ public abstract class DataTableColumnCore extends UIColumn {
 	public void setOrderBy(String _orderBy) {
 		getStateHelper().put(PropertyKeys.orderBy, _orderBy);
 	}
+
 
 	/**
 	 * Disables or enables the sort button for this column. <P>

--- a/src/main/meta/META-INF/bootsfaces-b.taglib.xml
+++ b/src/main/meta/META-INF/bootsfaces-b.taglib.xml
@@ -5661,6 +5661,18 @@
 		  <type>String</type>
 		</attribute>
 		<attribute>
+		  <description><![CDATA[Allows you to specify a value for ordering. Useful i.E. for ordering formatted values.]]></description>
+		  <name>data-order</name>
+		  <required>false</required>
+		  <type>java.lang.String</type>
+		</attribute>				
+		<attribute>
+		  <description><![CDATA[Allows you to specify a value for searching. Useful i.E. for searching formatted values.]]></description>
+		  <name>data-search</name>
+		  <required>false</required>
+		  <type>java.lang.String</type>
+		</attribute>				
+		<attribute>
 		  <description><![CDATA[Specifies order-by more precisely. Is also used by the filtering methods. Legal values are 'string', 'date', 'numeric'.]]></description>
 		  <name>data-type</name>
 		  <required>false</required>

--- a/xtext/BootsFaces.jsfdsl
+++ b/xtext/BootsFaces.jsfdsl
@@ -541,6 +541,8 @@ widget dataTableColumn {
     label-style-class                                                      "The CSS class of the label."
     order                                                                  "Is the table to be sorted by this column? Legal values are 'asc' and 'desc'."
     order-by                                                               "Allows you to sort input field. Legal values are dom-text, dom-text-numeric, dom-select and dom-checkbox."
+	data-order															   "Allows you to specify a value for ordering. Useful i.E. for ordering formatted values."
+	data-search															   "Allows you to specify a value for searching. Useful i.E. for searching formatted values."
     data-type                                                              "Specifies order-by more precisely. Is also used by the filtering methods. Legal values are 'string', 'date', 'numeric'."
 	content-style                                                          "Inline style of the cells in the content area."
     content-style-class                                                    "Style class of cells in the content area.."


### PR DESCRIPTION
Allows to specify values for ordering or searching. Useful i.E. with
formatted values (like a localized Date).

Example:
<b:dataTableColumn label="Date" order="asc" data-order="#{
dateValue.toGMTString() }" data-type="date">
	<h:outputText value="#{ dateValue }">
		<f:convertDateTime dateStyle="medium" />
	</h:outputText>
</b:dataTableColumn>

Fix TheCoder4eu/BootsFaces-OSP#591