### PR TITLE
added 'info' property to b:dataTable

### DIFF
--- a/src/main/java/net/bootsfaces/component/dataTable/DataTableCore.java
+++ b/src/main/java/net/bootsfaces/component/dataTable/DataTableCore.java
@@ -28,7 +28,7 @@ import net.bootsfaces.component.dataTable.DataTable.DataTablePropertyType;
 public abstract class DataTableCore extends UIData implements net.bootsfaces.render.IHasTooltip {
 
 	protected enum PropertyKeys {
-		ajax, border, colLg, colMd, colSm, colXs, customLangUrl, customOptions, disabled, display, fixedHeader, hidden, immediate, lang, largeScreen, mediumScreen, multiColumnSearch, offset, offsetLg, offsetMd, offsetSm, offsetXs, onclick, oncomplete, ondblclick, ondeselect, onmousedown, onmousemove, onmouseout, onmouseover, onmouseup, onorder, onpage, onsearch, onselect, pageLength, pageLengthMenu, paginated, process, responsive, rowHighlight, saveState, scrollCollapse, scrollSize, scrollX, searching, select, selectionMode, smallScreen, span, striped, style, styleClass, tinyScreen, tooltip, tooltipContainer, tooltipDelay, tooltipDelayHide, tooltipDelayShow, tooltipPosition, update, visible, widgetVar;
+		ajax, border, colLg, colMd, colSm, colXs, customLangUrl, customOptions, disabled, display, fixedHeader, hidden, immediate, info, lang, largeScreen, mediumScreen, multiColumnSearch, offset, offsetLg, offsetMd, offsetSm, offsetXs, onclick, oncomplete, ondblclick, ondeselect, onmousedown, onmousemove, onmouseout, onmouseover, onmouseup, onorder, onpage, onsearch, onselect, pageLength, pageLengthMenu, paginated, process, responsive, rowHighlight, saveState, scrollCollapse, scrollSize, scrollX, searching, select, selectionMode, smallScreen, span, striped, style, styleClass, tinyScreen, tooltip, tooltipContainer, tooltipDelay, tooltipDelayHide, tooltipDelayShow, tooltipPosition, update, visible, widgetVar;
 		String toString;
 
 		PropertyKeys(String toString) {
@@ -250,7 +250,23 @@ public abstract class DataTableCore extends UIData implements net.bootsfaces.ren
 	public void setImmediate(boolean _immediate) {
 		getStateHelper().put(PropertyKeys.immediate, _immediate);
 	}
+	
+	/**
+	 * If set, this will enable the information about record count. Defaults to true. <P>
+	 * @return Returns the value of the attribute, or true, if it hasn't been set by the JSF file.
+	 */
+	public boolean isInfo() {
+		return (boolean) (Boolean) getStateHelper().eval(PropertyKeys.info, true);
+	}
 
+	/**
+	 * If set, this will enable the information about record count. Defaults to true. <P>
+	 * Usually this method is called internally by the JSF engine.
+	 */
+	public void setInfo(boolean _info) {
+		getStateHelper().put(PropertyKeys.info, _info);
+	}
+	
 	/**
 	 * Configured lang for the dataTable. If no default language is configured, the language configured in the browser is used. <P>
 	 * @return Returns the value of the attribute, or null, if it hasn't been set by the JSF file.

--- a/src/main/java/net/bootsfaces/component/dataTable/DataTableRenderer.java
+++ b/src/main/java/net/bootsfaces/component/dataTable/DataTableRenderer.java
@@ -532,7 +532,7 @@ public class DataTableRenderer extends CoreRenderer {
 		options = addOptions("fixedHeader: " + dataTable.isFixedHeader(), options);
 		options = addOptions( "responsive: " + dataTable.isResponsive(), options);
 		options = addOptions( "paging: " + dataTable.isPaginated(), options);
-		if (!dataTable.isPaginated()) {
+		if (!dataTable.isInfo()) {
 			options = addOptions( "info: false", options);
 		}
 		options = addOptions( "pageLength: " + pageLength, options);

--- a/src/main/meta/META-INF/bootsfaces-b.taglib.xml
+++ b/src/main/meta/META-INF/bootsfaces-b.taglib.xml
@@ -5168,6 +5168,12 @@
 		  <type>java.lang.Boolean</type>
 		</attribute>
 		<attribute>
+		  <description><![CDATA[If set, this will enable the information about record count. Defaults to true.]]></description>
+		  <name>info</name>
+		  <required>false</required>
+		  <type>java.lang.Boolean</type>
+		</attribute>
+		<attribute>
 		  <description><![CDATA[Configured lang for the dataTable. If no default language is configured, the language configured in the browser is used.]]></description>
 		  <name>lang</name>
 		  <required>false</required>

--- a/xtext/BootsFaces.jsfdsl
+++ b/xtext/BootsFaces.jsfdsl
@@ -494,6 +494,7 @@ widget dataTable
 	fixed-header         Boolean                                           "Activates the fixed header plugin of the dataTable."
     id                   inherited                                         "Unique identifier of the component in a namingContainer."
     immediate            Boolean                                           "Flag indicating that, if this component is activated by the user, notifications should be delivered to interested listeners and actions immediately (that is, during Apply Request Values phase) rather than waiting until Invoke Application phase. Default is false."
+    info				 Boolean default "true"							   "If set, this will enable the information about record count. Defaults to true."
 	lang                 String                                            "Configured lang for the dataTable. If no default language is configured, the language configured in the browser is used."
     multi-column-search  Boolean                                           "If true, &lt;b:inputText /&gt; fields will be generated at the bottom of each column which allow you to perform per-column filtering."
 //    multi-column-search-position default "bottom"                          "Doesn't work yet. Should the multi-column-search attributes be at the bottom or the top of the table? Legal values: 'top','botton', and 'both'. Default to 'bottom'."


### PR DESCRIPTION
info property should be independent from paginated option. Offering more
flexibility.

I require a separation of the info display from the paginated option. Added option "info" instead hiding the info if "paginated" is disabled. Hope you like it.