### PR TITLE
href and target on b:button

### DIFF
--- a/src/main/java/net/bootsfaces/component/button/Button.java
+++ b/src/main/java/net/bootsfaces/component/button/Button.java
@@ -326,7 +326,7 @@ public class Button extends HtmlOutcomeTargetButton implements IHasTooltip, IRes
 	}
 	
 	/**
-	 * This column is hidden on a certain screen size and below. Legal values: lg, md, sm, xs. <P>
+	 * Specifies the URL of the page the link goes to. <P>
 	 * @return Returns the value of the attribute, or null, if it hasn't been set by the JSF file.
 	 */
 	public String getHref() {
@@ -334,7 +334,7 @@ public class Button extends HtmlOutcomeTargetButton implements IHasTooltip, IRes
 	}
 
 	/**
-	 * This column is hidden on a certain screen size and below. Legal values: lg, md, sm, xs. <P>
+	 * Specifies the URL of the page the link goes to. <P>
 	 * Usually this method is called internally by the JSF engine.
 	 */
 	public void setHref(String _href) {

--- a/src/main/java/net/bootsfaces/component/button/Button.java
+++ b/src/main/java/net/bootsfaces/component/button/Button.java
@@ -70,6 +70,7 @@ public class Button extends HtmlOutcomeTargetButton implements IHasTooltip, IRes
 		display,
 		fragment,
 		hidden,
+		href,
 		icon,
 		iconAlign,
 		iconAwesome,
@@ -108,6 +109,7 @@ public class Button extends HtmlOutcomeTargetButton implements IHasTooltip, IRes
 		style,
 		styleClass,
 		tabindex,
+		target,
 		tinyScreen,
 		title,
 		tooltip,
@@ -321,6 +323,22 @@ public class Button extends HtmlOutcomeTargetButton implements IHasTooltip, IRes
 	 */
 	public void setHidden(String _hidden) {
 		getStateHelper().put(PropertyKeys.hidden, _hidden);
+	}
+	
+	/**
+	 * This column is hidden on a certain screen size and below. Legal values: lg, md, sm, xs. <P>
+	 * @return Returns the value of the attribute, or null, if it hasn't been set by the JSF file.
+	 */
+	public String getHref() {
+		return (String) getStateHelper().eval(PropertyKeys.href);
+	}
+
+	/**
+	 * This column is hidden on a certain screen size and below. Legal values: lg, md, sm, xs. <P>
+	 * Usually this method is called internally by the JSF engine.
+	 */
+	public void setHref(String _href) {
+		getStateHelper().put(PropertyKeys.href, _href);
 	}
 
 	/**
@@ -929,6 +947,22 @@ public class Button extends HtmlOutcomeTargetButton implements IHasTooltip, IRes
 	 */
 	public void setTabindex(String _tabindex) {
 		getStateHelper().put(PropertyKeys.tabindex, _tabindex);
+	}
+	
+	/**
+	 * The target attribute specifies where to open the linked document. <P>
+	 * @return Returns the value of the attribute, or null, if it hasn't been set by the JSF file.
+	 */
+	public String getTarget() {
+		return (String) getStateHelper().eval(PropertyKeys.target);
+	}
+
+	/**
+	 * The target attribute specifies where to open the linked document. <P>
+	 * Usually this method is called internally by the JSF engine.
+	 */
+	public void setTarget(String _target) {
+		getStateHelper().put(PropertyKeys.target, _target);
 	}
 
 	/**

--- a/src/main/java/net/bootsfaces/component/button/ButtonRenderer.java
+++ b/src/main/java/net/bootsfaces/component/button/ButtonRenderer.java
@@ -176,7 +176,10 @@ public class ButtonRenderer extends CoreRenderer {
 				if (!fragment.startsWith("#")) {
 					fragment = "#" + fragment;
 				}
-				js += "window.location.href='" + fragment + "';";
+				js += "window.open('" + fragment + "'";
+				if (button.getTarget() != null)
+					js += ", '" + button.getTarget() + "'";
+				js += ");";
 				return js;
 			}
 		}
@@ -200,7 +203,10 @@ public class ButtonRenderer extends CoreRenderer {
 							url += "#" + fragment;
 						}
 					}
-					js += "window.location.href='" + url + "';";
+					js += "window.open('" + url + "'";
+					if (button.getTarget() != null)
+						js += ", '" + button.getTarget() + "'";
+					js += ");";
 				}
 			}
 		}

--- a/src/main/java/net/bootsfaces/component/button/ButtonRenderer.java
+++ b/src/main/java/net/bootsfaces/component/button/ButtonRenderer.java
@@ -80,7 +80,7 @@ public class ButtonRenderer extends CoreRenderer {
 		Object value = (button.getValue() != null ? button.getValue() : "");
 		String style = button.getStyle();
 
-		rw.startElement("button", button);
+		rw.startElement("a", button);
 		rw.writeAttribute("id", clientId, "id");
 		rw.writeAttribute("name", clientId, "name");
 		rw.writeAttribute("type", "button", null);
@@ -90,6 +90,10 @@ public class ButtonRenderer extends CoreRenderer {
 		if (style != null) {
 			rw.writeAttribute("style", style, "style");
 		}
+		if (button.getHref() != null)
+			rw.writeAttribute("href", button.getHref(), "href");
+		if (button.getTarget() != null)
+			rw.writeAttribute("target", button.getTarget(), "target");
 		rw.writeAttribute("class", getStyleClasses(button), "class");
 
 		Tooltip.generateTooltip(context, button, rw);
@@ -131,7 +135,7 @@ public class ButtonRenderer extends CoreRenderer {
 		}
 
 		Tooltip.activateTooltips(context, button);
-		rw.endElement("button");
+		rw.endElement("a");
 	}
 
 	/**

--- a/src/main/java/net/bootsfaces/component/button/ButtonRenderer.java
+++ b/src/main/java/net/bootsfaces/component/button/ButtonRenderer.java
@@ -176,10 +176,12 @@ public class ButtonRenderer extends CoreRenderer {
 				if (!fragment.startsWith("#")) {
 					fragment = "#" + fragment;
 				}
-				js += "window.open('" + fragment + "'";
+				js += "window.open('" + fragment + "', '";
 				if (button.getTarget() != null)
-					js += ", '" + button.getTarget() + "'";
-				js += ");";
+					js += button.getTarget();
+				else
+					js += "_self";
+				js += "');";
 				return js;
 			}
 		}
@@ -203,10 +205,12 @@ public class ButtonRenderer extends CoreRenderer {
 							url += "#" + fragment;
 						}
 					}
-					js += "window.open('" + url + "'";
+					js += "window.open('" + url + "', '";
 					if (button.getTarget() != null)
-						js += ", '" + button.getTarget() + "'";
-					js += ");";
+						js += button.getTarget();
+					else
+						js += "_self";
+					js += "');";
 				}
 			}
 		}


### PR DESCRIPTION
#652 
if the button is rendered as an anchor rather than a button in ResponseWriter it works okay and doesn't seem to affect anything.  does it specifically need to be a button?  outcome is called on target in onclick with window.open.  will this break backwards compatibility?