### PR TITLE
Fix Ajax call in DateTimePicker ondtchange wrapped in an Outer div

### DIFF
--- a/src/main/java/net/bootsfaces/component/dateTimePicker/DateTimePickerRenderer.java
+++ b/src/main/java/net/bootsfaces/component/dateTimePicker/DateTimePickerRenderer.java
@@ -62,7 +62,7 @@ public class DateTimePickerRenderer extends CoreRenderer {
 			fieldId = clientId + "_Input";
 		}
 		new AJAXRenderer().decode(context, dtp, fieldId);
-//		new AJAXRenderer().decode(context, dtp, clientId);
+		new AJAXRenderer().decode(context, dtp, clientId);
 	}
 
 	/**

--- a/src/main/java/net/bootsfaces/component/dateTimePicker/DateTimePickerRenderer.java
+++ b/src/main/java/net/bootsfaces/component/dateTimePicker/DateTimePickerRenderer.java
@@ -59,10 +59,10 @@ public class DateTimePickerRenderer extends CoreRenderer {
 		}
 		String fieldId = dtp.getFieldId();
 		if (null == fieldId) {
-			fieldId = clientId + "_Input";
+			fieldId = "input_" + clientId;
 		}
 		new AJAXRenderer().decode(context, dtp, fieldId);
-		new AJAXRenderer().decode(context, dtp, clientId);
+		// new AJAXRenderer().decode(context, dtp, clientId);
 	}
 
 	/**
@@ -186,7 +186,7 @@ public class DateTimePickerRenderer extends CoreRenderer {
 		
 		String fieldId = dtp.getFieldId();
 		if (null == fieldId) {
-			fieldId = clientId + "_Input";
+			fieldId = "input_" + clientId;
 		} else if (fieldId.equals(dtp.getId())) {
 			throw new FacesException("The field id must differ from the regular id.");
 		}
@@ -354,7 +354,7 @@ public class DateTimePickerRenderer extends CoreRenderer {
 		String clientId = dtp.getClientId();
 		String fieldId = dtp.getFieldId();
 		if (null == fieldId) {
-			fieldId = clientId + "_Input";
+			fieldId = "input_" + clientId;
 		} else if (fieldId.equals(dtp.getId())) {
 			throw new FacesException("The field id must differ from the regular id.");
 		}


### PR DESCRIPTION
This fixes Ajax call inside DataTimePicker ondtchange events. Since change of commit TheCoder4eu@821dfca Ajax calls are not executed any more on server side, if DateTimePicker is wrapped in an Outer container.

Example:

	<b:dateTimePicker id="dtp" value="#{ bean.dtpValue }"
				label="DTP Test with AJAX" render-label="true" span="6" show-time="false"
				format="MM.YYYY" tabindex="1" ajax="true" immediate="true" viewMode="months"
				process="@this" update="@form:otherDtp @form:data"
				ondtchange="ajax:bean.updateFilter();" />

The generated Field id is now changed from clientId + "_Input" to "input_" + clientId to fulfill the requirements to be detected in AjaxRenderer