### PR TITLE
#806 Disabling BSF-Resources doesn´t work

### DIFF
--- a/src/main/java/net/bootsfaces/C.java
+++ b/src/main/java/net/bootsfaces/C.java
@@ -36,9 +36,26 @@ public final class C {
 
     //Theme
     public static final String BSF_LIBRARY="bsf";
+    
     public static final String P_USETHEME ="BootsFaces_USETHEME";
     public static final String P_THEME ="BootsFaces_THEME";
 
+    public static final String P_BLOCK_UI = "net.bootsfaces.blockUI";
+    
+	public static final String P_GET_JQUERYUI_FROM_CDN = "net.bootsfaces.get_jqueryui_from_cdn";
+	public static final String P_GET_JQUERY_FROM_CDN = "net.bootsfaces.get_jquery_from_cdn";
+	public static final String P_GET_BOOTSTRAP_FROM_CDN = "net.bootsfaces.get_bootstrap_from_cdn";
+	public static final String P_GET_FONTAWESOME_FROM_CDN = "net.bootsfaces.get_fontawesome_from_cdn";
+
+	// public static final String P_GET_BOOTSTRAP_COMPONENTS_FROM_CDN = "net.bootsfaces.get_bootstrap_components_from_cdn";
+
+	
+	
+
+	public static final String THEME_NAME_DEFAULT = "default";
+	public static final String THEME_NAME_OTHER = "other";
+
+    
     //Font Awesome
     //public static final String P_USEFONTAWESOME ="BootsFaces_USE_FA";
     public static final String FA_VERSION="4.7.0";


### PR DESCRIPTION
Addressing issue #806 to be able to load own version of Bootstrap - like described in https://showcase.bootsfaces.net/miscellaneous/Configuration.jsf ("Use your own version of jQuery, jQueryUI, FontAwesome, or Bootstrap instead of using the version BootsFaces brings").

Demo that fix is working: https://github.com/cljk/bsf-issue-806-example

Open issue: CSS of components still get added (perhaps to be fixed later). bsf.css is still added - which should be correct (and modified in the documentation).


Changes:
* move invoking removeBootstrapResources() to end of addCSS() (CSS files were removed and added again)
* fixed logic of "load Bootstrap from CDN" in addCSS() and renamed flag (compare to load jQuery logic)
* added position "last" to "bsf.js" to be able to add custom jQuery before (bsf.js depends on it)
* added named constants for paremeters