### PR TITLE
remove row class at line 136

### DIFF
--- a/src/main/java/net/bootsfaces/component/slider/SliderRenderer.java
+++ b/src/main/java/net/bootsfaces/component/slider/SliderRenderer.java
@@ -133,7 +133,7 @@ public class SliderRenderer extends BadgeRenderer {
 
                 rw.writeAttribute("class", getWithFeedback(getInputMode(slider.isInline()), slider), "class");
 		rw.startElement("div", null);
-		String s = "row " + (isVertical ? "slider-vertical" : "slider");
+		String s = (isVertical ? "slider-vertical" : "slider");
 		if (slider.getStyleClass()!=null) {
 			s += " " + slider.getStyleClass();
 		}


### PR DESCRIPTION
as suggested by @BonifacioJose i removed the row class and now the slider aligns properly in the showcase.  not sure what effect this will have on other operations?