### PR TITLE
allow Integer itemValue for selectMultiMenu besides String only

### DIFF
--- a/src/main/java/net/bootsfaces/component/selectMultiMenu/SelectMultiMenuRenderer.java
+++ b/src/main/java/net/bootsfaces/component/selectMultiMenu/SelectMultiMenuRenderer.java
@@ -637,6 +637,9 @@ public class SelectMultiMenuRenderer extends CoreInputRenderer {
 			String value;
 			if (itemValue instanceof String) {
 				value = (String) itemValue;
+			} else if (itemValue instanceof Integer) {
+				Integer intValue = ((Integer) itemValue);
+				value = intValue == null ? null : intValue.toString();
 			} else
 				value = String.valueOf(index);
 			rw.writeAttribute("value", value, "value");


### PR DESCRIPTION
Currently, only string values are allowed for selectMultiMenu items. A typical use case for such a component is to have a description in the label and an Integer in the value. Therefore, I added a cast to Integer for the itemValue and convert it to a String, so that the following construction should output a list of itemValues instead of a list of index values:

```java
public class MyBean() {
  private final Integer key;
  private String value;
  ...
}

public List<MyBean> myList;
...
public String myValue;
...
```
```xml
<b:selectMultiMenu value="#{myValue}">
  <f:selectItems value="#{myList}" var="l" itemValue="#{l.key}" itemLabel="#{l.value}" />
</b:selectMultiMenu>
```
One could argue that not only Integer, but also Float or Boolean can become important - well, the solution is easy. But imho, Integer ist much more important as I use this on database level as a primary key - description pair, mostly the primary key is from a generated index (and this is a number).

For pairs such as

| pk | description  |
|----|--------------|
| 10 | first choice |
| 23 | none of them |

I don't want `myValue` to have `0,1` as values if I select everything, but `10,23` instead.