### PR TITLE
b:modal is not readable by screen reader

### DIFF
--- a/src/main/java/net/bootsfaces/component/modal/ModalRenderer.java
+++ b/src/main/java/net/bootsfaces/component/modal/ModalRenderer.java
@@ -104,6 +104,7 @@ public class ModalRenderer extends CoreRenderer {
 			modalStyleClass = modalStyleClass + " " + modal.getSize();
 		}
 		rw.writeAttribute("class", modalStyleClass, "class");
+		rw.writeAttribute("role", "document", "role");
 
 		rw.startElement("div", component); // modal-content
 		rw.writeAttribute("class", "modal-content", "class");
@@ -126,6 +127,7 @@ public class ModalRenderer extends CoreRenderer {
 			rw.startElement("button", component);
 			rw.writeAttribute("type", "button", "type");
 			rw.writeAttribute("class", "close", "class");
+			rw.writeAttribute("aria-label", "Close", "aria-label");
 			rw.writeAttribute("data-dismiss", "modal", "data-dismiss");
 			rw.write("&times;");
 			rw.endElement("button");


### PR DESCRIPTION
Hi,
I'm using BootsFaces 1.3.0 with screen reader orca 3.22.2 on firefox 57.0.1
On opening a modal the screen readers reads the title but not the content.
If I try to use keydown to read below, it will key down on the main page and not the modal (thus it reads things that are hidden behind the modal so the user feels very lost).
Using tabs allows to navigate between the title, the cross close button (which would gain to have an aria-label="close"), and the close and ok button. There is no way to read the text content.

It is very weird because the bootstrap one works fine and it is implemented the same way. The only difference I see is that we are missing role="document" on the second level container. Could this be the reason??...