### PR TITLE
fixed modal accessibility issue

### DIFF
--- a/src/main/java/net/bootsfaces/component/modal/ModalRenderer.java
+++ b/src/main/java/net/bootsfaces/component/modal/ModalRenderer.java
@@ -55,13 +55,13 @@ public class ModalRenderer extends CoreRenderer {
 		}
 		/*
 		 * <div id="myModal" class="modal fade" tabindex="-1" role="dialog"
-		 * aria-labelledby="myModalLabel" aria-hidden="true"> <div
+		 * aria-labelledby="myModalLabel" > <div
 		 * class="modal-dialog"> <div class="modal-content"> <div
 		 * class="modal-header"> <button type="button" class="close"
-		 * data-dismiss="modal" aria-hidden="true">×</button> <h3
+		 * data-dismiss="modal" a>×</button> <h3
 		 * id="myModalLabel">Modal header</h3> </div> <div class="modal-body">
 		 * <p>One fine body…</p> </div> <div class="modal-footer"> <button
-		 * class="btn" data-dismiss="modal" aria-hidden="true">Close</button>
+		 * class="btn" data-dismiss="modal" >Close</button>
 		 * <button class="btn btn-primary">Save changes</button> </div>
 		 * </div><!-- /.modal-content --> </div><!-- /.modal-dialog -->
 		 * </div><!-- /.modal -->
@@ -96,7 +96,7 @@ public class ModalRenderer extends CoreRenderer {
 		rw.writeAttribute("role", "dialog", null);
 		rw.writeAttribute("tabindex", "-1", null);
 		rw.writeAttribute("aria-labelledby", cid + "_Label", null);
-		rw.writeAttribute("aria-hidden", "true", null);
+		//rw.writeAttribute("aria-hidden", "true", null);
 
 		rw.startElement("div", component); // modal-dialog
 		String modalStyleClass = "modal" + "-dialog";


### PR DESCRIPTION
removed the aria-hidden=true that made the modal invisible for the screen reader.
Fix #1009 

I found what was really causing the issue with the screen reader ~:star:
the aria-hidden=true is still there when the modal is open that is why it gets ignored! 

The problem is that aria-hidden was introduced in the bootstrap 4 modal but we are using the bootsrap 3 modal.js.
If BF stays with bootsraps 3 we can't use the aria-hiddenfor this component.