### PR TITLE
Fix fixed height for InputText with tags

### DIFF
--- a/mavenResources/META-INF/resources/bsf/css/input-tags.css
+++ b/mavenResources/META-INF/resources/bsf/css/input-tags.css
@@ -1,0 +1,14 @@
+.bootstrap-tagsinput {
+	height: auto;
+	min-height: 34px;
+}
+
+.bootstrap-tagsinput .twitter-typeahead {
+	width: auto;
+	float: none;
+	position: relative !important;
+}
+
+.bootstrap-tagsinput .twitter-typeahead .tt-menu {
+	width: auto;
+}

--- a/src/main/java/net/bootsfaces/component/inputText/InputText.java
+++ b/src/main/java/net/bootsfaces/component/inputText/InputText.java
@@ -152,7 +152,7 @@ public String getFamily() {
 			AddResourcesListener.addResourceToHeadButAfterJQuery(C.BSF_LIBRARY, "js/bootstrap-tagsinput.min.js");
 			AddResourcesListener.addExtCSSResource("bootstrap-tagsinput.css");
 			AddResourcesListener.addExtCSSResource("bootstrap-tagsinput-typeahead.css");
-
+			AddResourcesListener.addExtCSSResource("input-tags.css");
 		}
 		super.setTags(_tags);
 	}


### PR DESCRIPTION
This change adds custom CSS stylesheet for InputText with tags enabled.

The CSS rules make tagsinput wrapper's height automatic with minimum
height by default. Rules also fix editable input's position when
typeahead is enabled.

Fix #1081