### PR TITLE
Add DataTables "lengthChange" option

### DIFF
--- a/src/main/java/net/bootsfaces/component/dataTable/DataTableCore.java
+++ b/src/main/java/net/bootsfaces/component/dataTable/DataTableCore.java
@@ -26,7 +26,7 @@ public abstract class DataTableCore extends UIData implements net.bootsfaces.ren
 	protected enum PropertyKeys {
 		ajax, autoUpdate, border, caption, colLg, colMd, colSm, colXs, columnVisibility, contentDisabled, copy, csv,
 		customLangUrl, customOptions, delay, deselectOnBackdropClick, disabled, display, excel, fixedHeader, hidden,
-		immediate, info, lang, largeScreen, markSearchResults, mediumScreen, multiColumnSearch,
+		immediate, info, lang, largeScreen, lengthChange, markSearchResults, mediumScreen, multiColumnSearch,
 		multiColumnSearchPosition, offset, offsetLg, offsetMd, offsetSm, offsetXs, onclick, oncomplete, ondblclick,
 		ondeselect, onerror, onmousedown, onmousemove, onmouseout, onmouseover, onmouseup, onorder, onpage, onsearch,
 		onselect, onsuccess, pageLength, pageLengthMenu, paginated, pdf, print, process, responsive, rowGroup,
@@ -446,6 +446,22 @@ public abstract class DataTableCore extends UIData implements net.bootsfaces.ren
 	 */
 	public void setLargeScreen(String _largeScreen) {
 		getStateHelper().put(PropertyKeys.largeScreen, _largeScreen);
+	}
+
+	/**
+	 * Allows the user to disable the pageLength menu. Defaults to true. <P>
+	 * @return Returns the value of the attribute, or , false, if it hasn't been set by the JSF file.
+	 */
+	public boolean isLengthChange() {
+		return (boolean) (Boolean) getStateHelper().eval(PropertyKeys.lengthChange, true);
+	}
+
+	/**
+	 * Allows the user to disable the pageLength menu. Defaults to true. <P>
+	 * Usually this method is called internally by the JSF engine.
+	 */
+	public void setLengthChange(boolean _lengthChange) {
+		getStateHelper().put(PropertyKeys.lengthChange, _lengthChange);
 	}
 
 	/**

--- a/src/main/java/net/bootsfaces/component/dataTable/DataTableRenderer.java
+++ b/src/main/java/net/bootsfaces/component/dataTable/DataTableRenderer.java
@@ -573,6 +573,7 @@ public class DataTableRenderer extends CoreRenderer {
 		}
 		options = addOptions("pageLength: " + pageLength, options);
 		options = addOptions("lengthMenu: " + getPageLengthMenu(dataTable), options);
+		options = addOptions("lengthChange: " + dataTable.isLengthChange(), options);
 		options = addOptions("searching: " + dataTable.isSearching(), options);
 		options = addOptions("order: " + orderString, options);
 		options = addOptions("stateSave: " + dataTable.isSaveState(), options);

--- a/src/main/meta/META-INF/bootsfaces-b.taglib.xml
+++ b/src/main/meta/META-INF/bootsfaces-b.taglib.xml
@@ -6564,6 +6564,18 @@
 		  <type>java.lang.String</type>
 		</attribute>
 		<attribute>
+		  <description><![CDATA[Activates the page length menu of the dataTable. Default value is 'true'.]]></description>
+		  <name>length-change</name>
+		  <required>false</required>
+		  <type>java.lang.Boolean</type>
+		</attribute>
+		<attribute>
+		  <description><![CDATA[Activates the page length menu of the dataTable. Default value is 'true'.]]></description>
+		  <name>lengthChange</name>
+		  <required>false</required>
+		  <type>java.lang.Boolean</type>
+		</attribute>
+		<attribute>
 		  <description><![CDATA[If true, search results are marked yellow as you type. Based on mark.js (see https://datatables.net/blog/2017-01-19).]]></description>
 		  <name>mark-search-results</name>
 		  <required>false</required>

--- a/xtext/BootsFaces.jsfdsl
+++ b/xtext/BootsFaces.jsfdsl
@@ -571,6 +571,7 @@ widget dataTable
     immediate            Boolean                                           "Flag indicating that, if this component is activated by the user, notifications should be delivered to interested listeners and actions immediately (that is, during Apply Request Values phase) rather than waiting until Invoke Application phase. Default is false."
     info				 Boolean default "true"							      "If set, this will enable the information about record count. Defaults to true."
 	lang                 String                                            "Configured lang for the dataTable. If no default language is configured, the language configured in the browser is used."
+	length-change        Boolean  default "true"                           "Activates the page length menu of the dataTable"
     mark-search-results  Boolean                                           "If true, search results are marked yellow as you type. Based on mark.js (see https://datatables.net/blog/2017-01-19)."
     multi-column-search  Boolean                                           "If true, &lt;b:inputText /&gt; fields will be generated at the bottom of each column which allow you to perform per-column filtering."
     multi-column-search-position default "bottom"                          "Should the multi-column-search attributes be at the bottom or the top of the table? Legal values: 'top','botton', and 'both'. Default to 'bottom'."


### PR DESCRIPTION
This adds an attribute for the dataTables "lengthChange" property to the datatable. Offering the possibility to disable "false" the page length menu in the upper right. The default is "true", so it is still compatible with previous releases.