### PR TITLE
Fix for icons includes assigned by valueExpression (Replacement for 1099)

### DIFF
--- a/src/main/java/net/bootsfaces/component/button/Button.java
+++ b/src/main/java/net/bootsfaces/component/button/Button.java
@@ -63,6 +63,11 @@ public class Button extends HtmlOutcomeTargetButton implements IHasTooltip, IRes
 	public void setValueExpression(String name, ValueExpression binding) {
 		name = BsfUtils.snakeCaseToCamelCase(name);
 		super.setValueExpression(name, binding);
+				
+		if ("iconAwesome".equals(name))
+			AddResourcesListener.setNeedsFontsAwesome(this);
+		else if ("iconBrand".equals(name) || "iconLight".equals(name) || "iconRegular".equals(name) || "iconSolid".equals(name))
+			AddResourcesListener.setFontAwesomeVersion(5, this);
 	}
 
 	public void processEvent(ComponentSystemEvent event) throws AbortProcessingException {

--- a/src/main/java/net/bootsfaces/component/commandButton/CommandButton.java
+++ b/src/main/java/net/bootsfaces/component/commandButton/CommandButton.java
@@ -88,6 +88,11 @@ public class CommandButton extends CommandButtonCore
 	public void setValueExpression(String name, ValueExpression binding) {
 		name = BsfUtils.snakeCaseToCamelCase(name);
 		super.setValueExpression(name, binding);
+		
+		if ("iconAwesome".equals(name))
+			AddResourcesListener.setNeedsFontsAwesome(this);
+		else if ("iconBrand".equals(name) || "iconLight".equals(name) || "iconRegular".equals(name) || "iconSolid".equals(name))
+			AddResourcesListener.setFontAwesomeVersion(5, this);
 	}
 
 	/**

--- a/src/main/java/net/bootsfaces/component/dateTimePicker/DateTimePicker.java
+++ b/src/main/java/net/bootsfaces/component/dateTimePicker/DateTimePicker.java
@@ -134,6 +134,11 @@ public class DateTimePicker extends DateTimePickerCore
 	public void setValueExpression(String name, ValueExpression binding) {
 		name = BsfUtils.snakeCaseToCamelCase(name);
 		super.setValueExpression(name, binding);
+		
+		if ("iconAwesome".equals(name))
+			AddResourcesListener.setNeedsFontsAwesome(this);
+		else if ("iconBrand".equals(name) || "iconLight".equals(name) || "iconRegular".equals(name) || "iconSolid".equals(name))
+			AddResourcesListener.setFontAwesomeVersion(5, this);
 	}
 
 	/**

--- a/src/main/java/net/bootsfaces/component/dropButton/DropButton.java
+++ b/src/main/java/net/bootsfaces/component/dropButton/DropButton.java
@@ -61,6 +61,11 @@ public class DropButton extends UIComponentBase implements IHasTooltip, IRespons
 	public void setValueExpression(String name, ValueExpression binding) {
 		name = BsfUtils.snakeCaseToCamelCase(name);
 		super.setValueExpression(name, binding);
+		
+		if ("iconAwesome".equals(name))
+			AddResourcesListener.setNeedsFontsAwesome(this);
+		else if ("iconBrand".equals(name) || "iconLight".equals(name) || "iconRegular".equals(name) || "iconSolid".equals(name))
+			AddResourcesListener.setFontAwesomeVersion(5, this);
 	}
 
 	public String getFamily() {

--- a/src/main/java/net/bootsfaces/component/dropMenu/DropMenu.java
+++ b/src/main/java/net/bootsfaces/component/dropMenu/DropMenu.java
@@ -61,6 +61,11 @@ public class DropMenu extends DropMenuCore implements IHasTooltip, IResponsive, 
 	public void setValueExpression(String name, ValueExpression binding) {
 		name = BsfUtils.snakeCaseToCamelCase(name);
 		super.setValueExpression(name, binding);
+		
+		if ("iconAwesome".equals(name))
+			AddResourcesListener.setNeedsFontsAwesome(this);
+		else if ("iconBrand".equals(name) || "iconLight".equals(name) || "iconRegular".equals(name) || "iconSolid".equals(name))
+			AddResourcesListener.setFontAwesomeVersion(5, this);
 	}
 
 	public void processEvent(ComponentSystemEvent event) throws AbortProcessingException {

--- a/src/main/java/net/bootsfaces/component/inputText/InputText.java
+++ b/src/main/java/net/bootsfaces/component/inputText/InputText.java
@@ -127,6 +127,10 @@ public class InputText extends InputTextCore implements IHasTooltip, IAJAXCompon
 	public void setValueExpression(String name, ValueExpression binding) {
 		name = BsfUtils.snakeCaseToCamelCase(name);
 		super.setValueExpression(name, binding);
+
+		if ("mask".equals(name)) addInputmaskResources();
+		else if ("typeahead".equals(name)) addTypeaheadResources();
+		else if ("tags".equals(name)) addTagsResources();
 	}
 
 	@Override
@@ -149,10 +153,7 @@ public String getFamily() {
 	 */
 	public void setTags(boolean _tags) {
 		if (_tags) {
-			AddResourcesListener.addResourceToHeadButAfterJQuery(C.BSF_LIBRARY, "js/bootstrap-tagsinput.min.js");
-			AddResourcesListener.addExtCSSResource("bootstrap-tagsinput.css");
-			AddResourcesListener.addExtCSSResource("bootstrap-tagsinput-typeahead.css");
-			AddResourcesListener.addExtCSSResource("input-tags.css");
+			addTagsResources();
 		}
 		super.setTags(_tags);
 	}
@@ -164,8 +165,7 @@ public String getFamily() {
 	@Override
 	public void setTypeahead(boolean _typeahead) {
 		if (_typeahead) {
-			AddResourcesListener.addResourceToHeadButAfterJQuery(C.BSF_LIBRARY, "js/typeahead.js");
-			AddResourcesListener.addExtCSSResource("typeahead.css");
+			addTypeaheadResources();
 		}
 		super.setTypeahead(_typeahead);
 	}
@@ -192,9 +192,24 @@ public String getFamily() {
    */
 	public void setMask(String mask) {
 		if (mask != null && !mask.isEmpty()) {
-			AddResourcesListener.addResourceToHeadButAfterJQuery(C.BSF_LIBRARY, "js/jquery.inputmask.bundle.min.js");
+			addInputmaskResources();
 		}
     getStateHelper().put(PropertyKeys.mask, mask);
 	}
-  
+	
+	private void addInputmaskResources() {
+		AddResourcesListener.addResourceToHeadButAfterJQuery(C.BSF_LIBRARY, "js/jquery.inputmask.bundle.min.js");		
+	}
+
+	private void addTypeaheadResources() {
+		AddResourcesListener.addResourceToHeadButAfterJQuery(C.BSF_LIBRARY, "js/typeahead.js");
+		AddResourcesListener.addExtCSSResource("typeahead.css");
+	}
+	
+	private void addTagsResources() {
+		AddResourcesListener.addResourceToHeadButAfterJQuery(C.BSF_LIBRARY, "js/bootstrap-tagsinput.min.js");
+		AddResourcesListener.addExtCSSResource("bootstrap-tagsinput.css");
+		AddResourcesListener.addExtCSSResource("bootstrap-tagsinput-typeahead.css");
+		AddResourcesListener.addExtCSSResource("input-tags.css");
+	}
 }

--- a/src/main/java/net/bootsfaces/component/navCommandLink/NavCommandLink.java
+++ b/src/main/java/net/bootsfaces/component/navCommandLink/NavCommandLink.java
@@ -64,6 +64,11 @@ public class NavCommandLink extends NavCommandLinkCore implements ClientBehavior
 	public void setValueExpression(String name, ValueExpression binding) {
 		name = BsfUtils.snakeCaseToCamelCase(name);
 		super.setValueExpression(name, binding);
+		
+		if ("iconAwesome".equals(name))
+			AddResourcesListener.setNeedsFontsAwesome(this);
+		else if ("iconBrand".equals(name) || "iconLight".equals(name) || "iconRegular".equals(name) || "iconSolid".equals(name))
+			AddResourcesListener.setFontAwesomeVersion(5, this);
 	}
 
 	private static final Collection<String> EVENT_NAMES = Collections

--- a/src/main/java/net/bootsfaces/component/navLink/NavLink.java
+++ b/src/main/java/net/bootsfaces/component/navLink/NavLink.java
@@ -65,6 +65,11 @@ public class NavLink extends NavLinkCore implements ClientBehaviorHolder, net.bo
 	public void setValueExpression(String name, ValueExpression binding) {
 		name = BsfUtils.snakeCaseToCamelCase(name);
 		super.setValueExpression(name, binding);
+		
+		if ("iconAwesome".equals(name))
+			AddResourcesListener.setNeedsFontsAwesome(this);
+		else if ("iconBrand".equals(name) || "iconLight".equals(name) || "iconRegular".equals(name) || "iconSolid".equals(name))
+			AddResourcesListener.setFontAwesomeVersion(5, this);
 	}
 
 	private static final Collection<String> EVENT_NAMES = Collections

--- a/src/main/java/net/bootsfaces/component/panel/Panel.java
+++ b/src/main/java/net/bootsfaces/component/panel/Panel.java
@@ -71,6 +71,11 @@ public class Panel extends UIComponentBase implements net.bootsfaces.render.IHas
 	public void setValueExpression(String name, ValueExpression binding) {
 		name = BsfUtils.snakeCaseToCamelCase(name);
 		super.setValueExpression(name, binding);
+		
+		if ("iconAwesome".equals(name))
+			AddResourcesListener.setNeedsFontsAwesome(this);
+		else if ("iconBrand".equals(name) || "iconLight".equals(name) || "iconRegular".equals(name) || "iconSolid".equals(name))
+			AddResourcesListener.setFontAwesomeVersion(5, this);
 	}
 
 	public String getFamily() {


### PR DESCRIPTION
if a valueExpression was used for properties that toggles the inclusion of scripts or css if a constant value is passed these inclusion were not added . By adding some additional code to setValueExpression these forces adding the required libraries, even if the final value may be empty or null, which isn't known during set.

Fixes #1098
Fixes #1052

This is a replacement for PR 1099. Limited to the relevant files only. Hopefully not forgotten anything.